### PR TITLE
Scroll back to top, and then back to where you were

### DIFF
--- a/src/features/shared/scroll/ScrollToTopFab.tsx
+++ b/src/features/shared/scroll/ScrollToTopFab.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { IonFab, IonFabButton, IonIcon } from "@ionic/react";
+import { chevronDownOutline, chevronUpOutline } from "ionicons/icons";
+
+interface ScrollToTopFabProps {
+  onClick: () => void;
+  activated: boolean;
+}
+
+const ScrollToTopFab: React.FC<ScrollToTopFabProps> = ({
+  onClick,
+  activated,
+}) => {
+  return (
+    <IonFab
+      vertical="bottom"
+      horizontal="end"
+      slot="fixed"
+      activated={activated}
+    >
+      <IonFabButton onClick={onClick} closeIcon={chevronDownOutline}>
+        <IonIcon icon={chevronUpOutline} />
+      </IonFabButton>
+    </IonFab>
+  );
+};
+
+export default ScrollToTopFab;

--- a/src/features/shared/scroll/scrollUtils.tsx
+++ b/src/features/shared/scroll/scrollUtils.tsx
@@ -1,0 +1,69 @@
+import { RefObject } from "react";
+import { VirtuosoHandle } from "react-virtuoso";
+
+function findScrollEl(activePage: HTMLElement) {
+  return (
+    activePage?.querySelector('[data-virtuoso-scroller="true"]') ??
+    activePage
+      ?.querySelector("ion-content")
+      ?.shadowRoot?.querySelector(".inner-scroll")
+  );
+}
+
+export function activateFabOnPagePosition(
+  activePage: HTMLElement | RefObject<VirtuosoHandle> | undefined,
+  previousTop: number,
+  activated: boolean,
+  setActivated: (arg0: boolean) => void
+) {
+  if (!activated || !activePage) return;
+  if ("querySelector" in activePage) {
+    const scroll = findScrollEl(activePage);
+
+    if (scroll?.scrollTop) {
+      setActivated(scroll.scrollTop !== previousTop);
+    }
+  } else {
+    activePage.current?.getState((state) => {
+      setActivated(state.scrollTop !== 0);
+    });
+  }
+}
+
+export async function scrollFabIfNeeded(
+  activePage: HTMLElement | RefObject<VirtuosoHandle> | undefined,
+  previousTop: number,
+  setPreviousTop: (arg0: number) => void,
+  setActivated: (arg0: boolean) => void
+) {
+  if (!activePage) return false;
+
+  if ("querySelector" in activePage) {
+    const scroll = findScrollEl(activePage);
+
+    if (scroll?.scrollTop) {
+      scroll.scrollTo({
+        top: scroll.scrollTop ? 0 : previousTop,
+        behavior: "smooth",
+      });
+      setPreviousTop(scroll.scrollTop);
+      setActivated(scroll.scrollTop !== 0);
+      return true;
+    }
+  } else {
+    return new Promise((resolve) =>
+      activePage.current?.getState((state) => {
+        const shouldScroll = state.scrollTop !== previousTop;
+        if (shouldScroll) {
+          activePage.current?.scrollTo({
+            top: state.scrollTop ? 0 : previousTop,
+            behavior: "smooth",
+          });
+          setActivated(state.scrollTop !== 0);
+          setPreviousTop(state.scrollTop);
+        }
+        resolve(shouldScroll);
+      })
+    );
+  }
+}

--- a/src/pages/shared/CommunityPage.tsx
+++ b/src/pages/shared/CommunityPage.tsx
@@ -12,7 +12,7 @@ import AppBackButton from "../../features/shared/AppBackButton";
 import PostSort from "../../features/feed/PostSort";
 import MoreActions from "../../features/community/MoreActions";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { useCallback, useEffect } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getCommunity } from "../../features/community/communitySlice";
 import { useBuildGeneralBrowseLink } from "../../helpers/routes";
 import useClient from "../../helpers/useClient";
@@ -22,8 +22,17 @@ import PostCommentFeed, {
 } from "../../features/feed/PostCommentFeed";
 import { jwtSelector } from "../../features/auth/authSlice";
 import { NewPostContextProvider } from "../../features/post/new/NewPostModal";
+import ScrollToTopFab from "../../features/shared/scroll/ScrollToTopFab";
+import {
+  activateFabOnPagePosition,
+  scrollFabIfNeeded,
+} from "../../features/shared/scroll/scrollUtils";
+import { AppContext } from "../../features/auth/AppContext";
 
 export default function CommunityPage() {
+  const { activePage } = useContext(AppContext);
+  const [previousTop, setPreviousTop] = useState(0);
+  const [fabActivated, setFabActivated] = useState(false);
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
   const dispatch = useAppDispatch();
   const { community, actor } = useParams<{
@@ -70,7 +79,16 @@ export default function CommunityPage() {
 
   return (
     <NewPostContextProvider community={community}>
-      <IonPage>
+      <IonPage
+        onScrollCapture={() =>
+          activateFabOnPagePosition(
+            activePage,
+            previousTop,
+            fabActivated,
+            setFabActivated
+          )
+        }
+      >
         <IonHeader>
           <IonToolbar>
             <IonButtons slot="start">
@@ -90,6 +108,17 @@ export default function CommunityPage() {
         </IonHeader>
         <IonContent>
           <PostCommentFeed fetchFn={fetchFn} communityName={community} />
+          <ScrollToTopFab
+            activated={fabActivated}
+            onClick={() =>
+              scrollFabIfNeeded(
+                activePage,
+                previousTop,
+                setPreviousTop,
+                setFabActivated
+              )
+            }
+          />
         </IonContent>
       </IonPage>
     </NewPostContextProvider>

--- a/src/pages/shared/SpecialFeedPage.tsx
+++ b/src/pages/shared/SpecialFeedPage.tsx
@@ -8,7 +8,7 @@ import {
   IonToolbar,
 } from "@ionic/react";
 import { FetchFn } from "../../features/feed/Feed";
-import { useCallback } from "react";
+import { useCallback, useContext, useState } from "react";
 import PostSort from "../../features/feed/PostSort";
 import { ListingType } from "lemmy-js-client";
 import { useBuildGeneralBrowseLink } from "../../helpers/routes";
@@ -19,12 +19,21 @@ import PostCommentFeed, {
   PostCommentItem,
 } from "../../features/feed/PostCommentFeed";
 import { jwtSelector } from "../../features/auth/authSlice";
+import { AppContext } from "../../features/auth/AppContext";
+import {
+  activateFabOnPagePosition,
+  scrollFabIfNeeded,
+} from "../../features/shared/scroll/scrollUtils";
+import ScrollToTopFab from "../../features/shared/scroll/ScrollToTopFab";
 
 interface SpecialFeedProps {
   type: ListingType;
 }
 
 export default function SpecialFeedPage({ type }: SpecialFeedProps) {
+  const { activePage } = useContext(AppContext);
+  const [previousTop, setPreviousTop] = useState(0);
+  const [fabActivated, setFabActivated] = useState(false);
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
 
   const client = useClient();
@@ -46,7 +55,16 @@ export default function SpecialFeedPage({ type }: SpecialFeedProps) {
   );
 
   return (
-    <IonPage>
+    <IonPage
+      onScrollCapture={() =>
+        activateFabOnPagePosition(
+          activePage,
+          previousTop,
+          fabActivated,
+          setFabActivated
+        )
+      }
+    >
       <IonHeader>
         <IonToolbar>
           <IonButtons slot="start">
@@ -65,6 +83,17 @@ export default function SpecialFeedPage({ type }: SpecialFeedProps) {
       </IonHeader>
       <IonContent>
         <PostCommentFeed fetchFn={fetchFn} />
+        <ScrollToTopFab
+          activated={fabActivated}
+          onClick={() =>
+            scrollFabIfNeeded(
+              activePage,
+              previousTop,
+              setPreviousTop,
+              setFabActivated
+            )
+          }
+        />
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
In Apollo, a really handy feature to go back to the top on long threads is to tap the comment counter area at the top of the screen. In case of accidental tap, tapping the area again brings you back to where you were in the comments section.

In Wefwet, we don't have access to [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) which would enable status bar taps to scroll to the top. Instead I have used a floating action button to facilitate the same experience