### PR TITLE
Allow showing downvotes separately or hiding scores

### DIFF
--- a/src/features/gallery/GalleryPostActions.tsx
+++ b/src/features/gallery/GalleryPostActions.tsx
@@ -7,9 +7,12 @@ import { useAppSelector } from "../../store";
 import { useBuildGeneralBrowseLink } from "../../helpers/routes";
 import { getHandle } from "../../helpers/lemmy";
 import MoreActions from "../post/shared/MoreActions";
-import { calculateNetVoteCount, calculateVoteCounts } from "../../helpers/vote";
+import {
+  calculateTotalScore,
+  calculateSeparateScore,
+} from "../../helpers/vote";
 import { useLocation } from "react-router";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { GalleryContext } from "./GalleryProvider";
 import { OVoteDisplayMode } from "../../services/db";
 
@@ -73,7 +76,7 @@ export default function GalleryPostActions({ post }: GalleryPostActionsProps) {
   );
 }
 
-function Voting({ post }: GalleryPostActionsProps) {
+function Voting({ post }: GalleryPostActionsProps): React.ReactElement {
   const postVotesById = useAppSelector((state) => state.post.postVotesById);
 
   const voteDisplayMode = useAppSelector(
@@ -81,8 +84,22 @@ function Voting({ post }: GalleryPostActionsProps) {
   );
 
   switch (voteDisplayMode) {
-    case OVoteDisplayMode.SeparateScores: {
-      const { upvotes, downvotes } = calculateVoteCounts(post, postVotesById);
+    case OVoteDisplayMode.Total: {
+      const score = calculateTotalScore(post, postVotesById);
+
+      return (
+        <Section>
+          <VoteButton type="up" postId={post.post.id} />
+          <Amount>{score}</Amount>
+          <VoteButton type="down" postId={post.post.id} />
+        </Section>
+      );
+    }
+    case OVoteDisplayMode.Separate: {
+      const { upvotes, downvotes } = calculateSeparateScore(
+        post,
+        postVotesById
+      );
 
       return (
         <Section>
@@ -93,23 +110,12 @@ function Voting({ post }: GalleryPostActionsProps) {
         </Section>
       );
     }
-    case OVoteDisplayMode.NoScores:
+    case OVoteDisplayMode.Hide:
       return (
         <Section>
           <VoteButton type="up" postId={post.post.id} />
           <VoteButton type="down" postId={post.post.id} />
         </Section>
       );
-    default: {
-      const score = calculateNetVoteCount(post, postVotesById);
-
-      return (
-        <Section>
-          <VoteButton type="up" postId={post.post.id} />
-          <Amount>{score}</Amount>
-          <VoteButton type="down" postId={post.post.id} />
-        </Section>
-      );
-    }
   }
 }

--- a/src/features/gallery/GalleryPostActions.tsx
+++ b/src/features/gallery/GalleryPostActions.tsx
@@ -43,7 +43,7 @@ export default function GalleryPostActions({ post }: GalleryPostActionsProps) {
     `/c/${getHandle(post.community)}/comments/${post.post.id}`
   );
   const router = useIonRouter();
-  const score = calculateCurrentVotesCount(post, postVotesById);
+  const { score } = calculateCurrentVotesCount(post, postVotesById);
   const location = useLocation();
   const { close } = useContext(GalleryContext);
 

--- a/src/features/labels/Vote.tsx
+++ b/src/features/labels/Vote.tsx
@@ -3,7 +3,7 @@ import { IonIcon, useIonToast } from "@ionic/react";
 import { arrowDownSharp, arrowUpSharp } from "ionicons/icons";
 import styled from "@emotion/styled";
 import { voteOnPost } from "../post/postSlice";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { voteOnComment } from "../comment/commentSlice";
 import { voteError } from "../../helpers/toastMessages";
 import { PageContext } from "../auth/PageContext";
@@ -47,30 +47,33 @@ export default function Vote({ item, className }: VoteProps) {
 
   const { presentLoginIfNeeded } = useContext(PageContext);
 
+  async function do_vote(e: React.MouseEvent, vote: 0 | 1 | -1) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (presentLoginIfNeeded()) return;
+
+    let dispatcherFn;
+    if ("comment" in item) {
+      dispatcherFn = voteOnComment;
+    } else {
+      dispatcherFn = voteOnPost;
+    }
+
+    try {
+      await dispatch(dispatcherFn(id, vote));
+    } catch (error) {
+      present(voteError);
+      throw error;
+    }
+  }
+
   return (
     <Container
       className={className}
       vote={myVote as 1 | 0 | -1}
       onClick={async (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-
-        if (presentLoginIfNeeded()) return;
-
-        let dispatcherFn;
-        if ("comment" in item) {
-          dispatcherFn = voteOnComment;
-        } else {
-          dispatcherFn = voteOnPost;
-        }
-
-        try {
-          await dispatch(dispatcherFn(id, myVote ? 0 : 1));
-        } catch (error) {
-          present(voteError);
-
-          throw error;
-        }
+        await do_vote(e, myVote ? 0 : 1);
       }}
     >
       <IonIcon icon={myVote === -1 ? arrowDownSharp : arrowUpSharp} /> {score}

--- a/src/features/labels/Vote.tsx
+++ b/src/features/labels/Vote.tsx
@@ -9,7 +9,7 @@ import { voteError } from "../../helpers/toastMessages";
 import { PageContext } from "../auth/PageContext";
 import { calculateCurrentVotesCount } from "../../helpers/vote";
 import { CommentView, PostView } from "lemmy-js-client";
-import { separateDownvotesSelector } from "../settings/appearance/appearanceSlice";
+import { OVoteDisplayMode } from "../../services/db";
 
 const Container = styled.div<{
   vote?: 1 | -1 | 0;
@@ -77,42 +77,60 @@ export default function Vote({ item, className }: VoteProps) {
     }
   }
 
-  if (useAppSelector(separateDownvotesSelector)) {
-    return (
-      <>
+  const voteDisplayMode = useAppSelector(
+    (state) => state.settings.appearance.voting.voteDisplayMode
+  );
+
+  switch (voteDisplayMode) {
+    case OVoteDisplayMode.SeparateScores:
+      return (
+        <>
+          <Container
+            className={className + "-up"}
+            vote={myVote}
+            voteRepresented={1}
+            onClick={async (e) => {
+              await do_vote(e, myVote === 1 ? 0 : 1);
+            }}
+          >
+            <IonIcon icon={arrowUpSharp} /> {upvotes}
+          </Container>
+          <Container
+            className={className + "-down"}
+            vote={myVote}
+            voteRepresented={-1}
+            onClick={async (e) => {
+              await do_vote(e, myVote === -1 ? 0 : -1);
+            }}
+          >
+            <IonIcon icon={arrowDownSharp} /> {downvotes}
+          </Container>
+        </>
+      );
+    case OVoteDisplayMode.NoScores:
+      return (
         <Container
-          className={className + "-up"}
+          className={className}
           vote={myVote}
-          voteRepresented={1}
           onClick={async (e) => {
-            await do_vote(e, myVote === 1 ? 0 : 1);
+            await do_vote(e, myVote ? 0 : 1);
           }}
         >
-          <IonIcon icon={arrowUpSharp} /> {upvotes}
+          <IonIcon icon={myVote === -1 ? arrowDownSharp : arrowUpSharp} />
         </Container>
+      );
+    default:
+      return (
         <Container
-          className={className + "-down"}
+          className={className}
           vote={myVote}
-          voteRepresented={-1}
           onClick={async (e) => {
-            await do_vote(e, myVote === -1 ? 0 : -1);
+            await do_vote(e, myVote ? 0 : 1);
           }}
         >
-          <IonIcon icon={arrowDownSharp} /> {downvotes}
+          <IonIcon icon={myVote === -1 ? arrowDownSharp : arrowUpSharp} />{" "}
+          {score}
         </Container>
-      </>
-    );
-  } else {
-    return (
-      <Container
-        className={className}
-        vote={myVote}
-        onClick={async (e) => {
-          await do_vote(e, myVote ? 0 : 1);
-        }}
-      >
-        <IonIcon icon={myVote === -1 ? arrowDownSharp : arrowUpSharp} /> {score}
-      </Container>
-    );
+      );
   }
 }

--- a/src/features/labels/Vote.tsx
+++ b/src/features/labels/Vote.tsx
@@ -7,7 +7,10 @@ import React, { useContext } from "react";
 import { voteOnComment } from "../comment/commentSlice";
 import { voteError } from "../../helpers/toastMessages";
 import { PageContext } from "../auth/PageContext";
-import { calculateNetVoteCount, calculateVoteCounts } from "../../helpers/vote";
+import {
+  calculateTotalScore,
+  calculateSeparateScore,
+} from "../../helpers/vote";
 import { CommentView, PostView } from "lemmy-js-client";
 import { OVoteDisplayMode } from "../../services/db";
 
@@ -35,10 +38,9 @@ const Container = styled.div<{
 
 interface VoteProps {
   item: PostView | CommentView;
-  className?: string;
 }
 
-export default function Vote({ item, className }: VoteProps) {
+export default function Vote({ item }: VoteProps): React.ReactElement {
   const [present] = useIonToast();
   const dispatch = useAppDispatch();
   const votesById = useAppSelector((state) =>
@@ -78,12 +80,11 @@ export default function Vote({ item, className }: VoteProps) {
   );
 
   switch (voteDisplayMode) {
-    case OVoteDisplayMode.SeparateScores: {
-      const { upvotes, downvotes } = calculateVoteCounts(item, votesById);
+    case OVoteDisplayMode.Separate: {
+      const { upvotes, downvotes } = calculateSeparateScore(item, votesById);
       return (
         <>
           <Container
-            className={className + "-up"}
             vote={myVote}
             voteRepresented={1}
             onClick={async (e) => {
@@ -93,7 +94,6 @@ export default function Vote({ item, className }: VoteProps) {
             <IonIcon icon={arrowUpSharp} /> {upvotes}
           </Container>
           <Container
-            className={className + "-down"}
             vote={myVote}
             voteRepresented={-1}
             onClick={async (e) => {
@@ -105,10 +105,9 @@ export default function Vote({ item, className }: VoteProps) {
         </>
       );
     }
-    case OVoteDisplayMode.NoScores:
+    case OVoteDisplayMode.Hide:
       return (
         <Container
-          className={className}
           vote={myVote}
           onClick={async (e) => {
             await onVote(e, myVote ? 0 : 1);
@@ -117,11 +116,11 @@ export default function Vote({ item, className }: VoteProps) {
           <IonIcon icon={myVote === -1 ? arrowDownSharp : arrowUpSharp} />
         </Container>
       );
+    // Total score
     default: {
-      const score = calculateNetVoteCount(item, votesById);
+      const score = calculateTotalScore(item, votesById);
       return (
         <Container
-          className={className}
           vote={myVote}
           onClick={async (e) => {
             await onVote(e, myVote ? 0 : 1);

--- a/src/features/settings/appearance/AppearanceSettings.tsx
+++ b/src/features/settings/appearance/AppearanceSettings.tsx
@@ -3,7 +3,7 @@ import Posts from "./posts/Posts";
 import System from "./system/System";
 import CompactSettings from "./CompactSettings";
 import GeneralAppearance from "./General";
-import Voting from "./Voting";
+import Votes from "./Votes";
 
 export default function AppearanceSettings() {
   return (
@@ -12,7 +12,7 @@ export default function AppearanceSettings() {
       <GeneralAppearance />
       <Posts />
       <CompactSettings />
-      <Voting />
+      <Votes />
       <System />
     </>
   );

--- a/src/features/settings/appearance/AppearanceSettings.tsx
+++ b/src/features/settings/appearance/AppearanceSettings.tsx
@@ -3,6 +3,7 @@ import Posts from "./posts/Posts";
 import System from "./system/System";
 import CompactSettings from "./CompactSettings";
 import GeneralAppearance from "./General";
+import Voting from "./Voting";
 
 export default function AppearanceSettings() {
   return (
@@ -11,6 +12,7 @@ export default function AppearanceSettings() {
       <GeneralAppearance />
       <Posts />
       <CompactSettings />
+      <Voting />
       <System />
     </>
   );

--- a/src/features/settings/appearance/CompactSettings.tsx
+++ b/src/features/settings/appearance/CompactSettings.tsx
@@ -1,38 +1,17 @@
-import type { IonActionSheetCustomEvent } from "@ionic/core";
-import {
-  ActionSheetButton,
-  IonLabel,
-  IonList,
-  IonActionSheet,
-  IonToggle,
-} from "@ionic/react";
+import { IonLabel, IonList, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../user/Profile";
 import { useAppSelector, useAppDispatch } from "../../../store";
-import { useState } from "react";
-import { startCase } from "lodash";
 import { setShowVotingButtons, setThumbnailPosition } from "../settingsSlice";
 import {
   OCompactThumbnailPositionType,
   CompactThumbnailPositionType,
 } from "../../../services/db";
-import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
 import { ListHeader } from "../shared/formatting";
-
-const BUTTONS: ActionSheetButton<CompactThumbnailPositionType>[] =
-  Object.values(OCompactThumbnailPositionType).map(function (
-    compactThumbnailPositionType
-  ) {
-    return {
-      text: startCase(compactThumbnailPositionType),
-      data: compactThumbnailPositionType,
-    } as ActionSheetButton<CompactThumbnailPositionType>;
-  });
+import SettingSelector from "../shared/SettingSelector";
 
 export default function CompactSettings() {
-  const [open, setOpen] = useState(false);
-
   const dispatch = useAppDispatch();
-  const compactThumbnailsPositionType = useAppSelector(
+  const compactThumbnailsPosition = useAppSelector(
     (state) => state.settings.appearance.compact.thumbnailsPosition
   );
 
@@ -40,40 +19,21 @@ export default function CompactSettings() {
     (state) => state.settings.appearance.compact.showVotingButtons
   );
 
+  const ThumbnailPositionSelector =
+    SettingSelector<CompactThumbnailPositionType>;
+
   return (
     <>
       <ListHeader>
         <IonLabel>Compact Posts</IonLabel>
       </ListHeader>
       <IonList inset>
-        <InsetIonItem button onClick={() => setOpen(true)}>
-          <IonLabel>Thumbnail Position</IonLabel>
-          <IonLabel slot="end" color="medium">
-            {startCase(compactThumbnailsPositionType)}
-          </IonLabel>
-          <IonActionSheet
-            cssClass="left-align-buttons"
-            isOpen={open}
-            onDidDismiss={() => setOpen(false)}
-            onWillDismiss={(
-              e: IonActionSheetCustomEvent<
-                OverlayEventDetail<CompactThumbnailPositionType>
-              >
-            ) => {
-              if (e.detail.data) {
-                dispatch(setThumbnailPosition(e.detail.data));
-              }
-            }}
-            header="Position"
-            buttons={BUTTONS.map((b) => ({
-              ...b,
-              role:
-                compactThumbnailsPositionType === b.data
-                  ? "selected"
-                  : undefined,
-            }))}
-          />
-        </InsetIonItem>
+        <ThumbnailPositionSelector
+          title="Thumbnail Position"
+          selected={compactThumbnailsPosition}
+          setSelected={setThumbnailPosition}
+          options={OCompactThumbnailPositionType}
+        />
         <InsetIonItem>
           <IonLabel>Show Voting Buttons</IonLabel>
           <IonToggle

--- a/src/features/settings/appearance/CompactSettings.tsx
+++ b/src/features/settings/appearance/CompactSettings.tsx
@@ -6,7 +6,6 @@ import {
   IonActionSheet,
   IonToggle,
 } from "@ionic/react";
-import { ListHeader } from "./TextSize";
 import { InsetIonItem } from "../../user/Profile";
 import { useAppSelector, useAppDispatch } from "../../../store";
 import { useState } from "react";
@@ -17,6 +16,7 @@ import {
   CompactThumbnailPositionType,
 } from "../../../services/db";
 import { OverlayEventDetail } from "@ionic/react/dist/types/components/react-component-lib/interfaces";
+import { ListHeader } from "../shared/formatting";
 
 const BUTTONS: ActionSheetButton<CompactThumbnailPositionType>[] =
   Object.values(OCompactThumbnailPositionType).map(function (

--- a/src/features/settings/appearance/General.tsx
+++ b/src/features/settings/appearance/General.tsx
@@ -1,16 +1,9 @@
-import styled from "@emotion/styled";
 import { IonLabel, IonList, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { setUserInstanceUrlDisplay } from "../settingsSlice";
 import { OInstanceUrlDisplayMode } from "../../../services/db";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../shared/formatting";
 
 export default function GeneralAppearance() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/appearance/TextSize.tsx
+++ b/src/features/settings/appearance/TextSize.tsx
@@ -4,13 +4,7 @@ import { IonLabel, IonList, IonRange, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { setFontSizeMultiplier, setUseSystemFontSize } from "../settingsSlice";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../shared/formatting";
 
 const Range = styled(IonRange)`
   --bar-background: var(--ion-color-medium);

--- a/src/features/settings/appearance/Votes.tsx
+++ b/src/features/settings/appearance/Votes.tsx
@@ -5,7 +5,7 @@ import { OVoteDisplayMode, VoteDisplayMode } from "../../../services/db";
 import SettingSelector from "../shared/SettingSelector";
 import { ListHeader } from "../shared/formatting";
 
-export default function CollapsedByDefault() {
+export default function Votes() {
   const voteDisplayMode = useAppSelector(
     (state) => state.settings.appearance.voting.voteDisplayMode
   );
@@ -15,13 +15,13 @@ export default function CollapsedByDefault() {
   return (
     <>
       <ListHeader>
-        <IonLabel>Voting</IonLabel>
+        <IonLabel>Votes</IonLabel>
       </ListHeader>
       <IonList inset>
         <Selector
-          title="Voting Display Mode"
+          title="Display Votes"
           selected={voteDisplayMode}
-          set_selected={setVoteDisplayMode}
+          setSelected={setVoteDisplayMode}
           options={OVoteDisplayMode}
         />
       </IonList>

--- a/src/features/settings/appearance/Voting.tsx
+++ b/src/features/settings/appearance/Voting.tsx
@@ -1,32 +1,16 @@
-import { IonActionSheet, IonLabel, IonList } from "@ionic/react";
-import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
-import { useAppDispatch, useAppSelector } from "../../../store";
-import { startCase } from "lodash";
-import { useState } from "react";
-import {
-  ActionSheetButton,
-  IonActionSheetCustomEvent,
-  OverlayEventDetail,
-} from "@ionic/core";
-import { OVoteDisplayMode, VoteDisplayMode } from "../../../services/db";
-import { ListHeader } from "./TextSize";
+import { IonLabel, IonList } from "@ionic/react";
+import { useAppSelector } from "../../../store";
 import { setVoteDisplayMode } from "../settingsSlice";
-
-const BUTTONS: ActionSheetButton<VoteDisplayMode>[] = Object.values(
-  OVoteDisplayMode
-).map(function (voteDisplayMode) {
-  return {
-    text: startCase(voteDisplayMode),
-    data: voteDisplayMode,
-  } as ActionSheetButton<VoteDisplayMode>;
-});
+import { OVoteDisplayMode, VoteDisplayMode } from "../../../services/db";
+import SettingSelector from "../shared/SettingSelector";
+import { ListHeader } from "../shared/formatting";
 
 export default function CollapsedByDefault() {
-  const [open, setOpen] = useState(false);
-  const dispatch = useAppDispatch();
   const voteDisplayMode = useAppSelector(
     (state) => state.settings.appearance.voting.voteDisplayMode
   );
+
+  const Selector = SettingSelector<VoteDisplayMode>;
 
   return (
     <>
@@ -34,29 +18,12 @@ export default function CollapsedByDefault() {
         <IonLabel>Voting</IonLabel>
       </ListHeader>
       <IonList inset>
-        <InsetIonItem button onClick={() => setOpen(true)}>
-          <IonLabel>Vote Display Mode</IonLabel>
-          <IonLabel slot="end" color="medium">
-            {startCase(voteDisplayMode)}
-          </IonLabel>
-          <IonActionSheet
-            cssClass="left-align-buttons"
-            isOpen={open}
-            onDidDismiss={() => setOpen(false)}
-            onWillDismiss={(
-              e: IonActionSheetCustomEvent<OverlayEventDetail<VoteDisplayMode>>
-            ) => {
-              if (e.detail.data) {
-                dispatch(setVoteDisplayMode(e.detail.data));
-              }
-            }}
-            header="Post Size"
-            buttons={BUTTONS.map((b) => ({
-              ...b,
-              role: voteDisplayMode === b.data ? "selected" : undefined,
-            }))}
-          />
-        </InsetIonItem>
+        <Selector
+          title="Voting Display Mode"
+          selected={voteDisplayMode}
+          set_selected={setVoteDisplayMode}
+          options={OVoteDisplayMode}
+        />
       </IonList>
     </>
   );

--- a/src/features/settings/appearance/Voting.tsx
+++ b/src/features/settings/appearance/Voting.tsx
@@ -1,0 +1,46 @@
+import styled from "@emotion/styled";
+import { IonLabel, IonList, IonToggle } from "@ionic/react";
+import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
+import { useAppDispatch, useAppSelector } from "../../../store";
+import { OVoteDisplayMode } from "../../../services/db";
+import { setVoteDisplayMode } from "../settingsSlice";
+
+export const ListHeader = styled.div`
+  font-size: 0.8em;
+  margin: 32px 0 -8px 32px;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+`;
+
+export default function CollapsedByDefault() {
+  const dispatch = useAppDispatch();
+  const { voteDisplayMode } = useAppSelector(
+    // this needs a better naming
+    (state) => state.settings.appearance.voting
+  );
+
+  return (
+    <>
+      <ListHeader>
+        <IonLabel>Voting</IonLabel>
+      </ListHeader>
+      <IonList inset>
+        <InsetIonItem>
+          <IonLabel>Show downvotes separately</IonLabel>
+          <IonToggle
+            checked={voteDisplayMode === OVoteDisplayMode.Separate}
+            onIonChange={(e) =>
+              dispatch(
+                setVoteDisplayMode(
+                  e.detail.checked
+                    ? OVoteDisplayMode.Separate
+                    : OVoteDisplayMode.SingleScore
+                )
+              )
+            }
+          />
+        </InsetIonItem>
+      </IonList>
+    </>
+  );
+}

--- a/src/features/settings/appearance/Voting.tsx
+++ b/src/features/settings/appearance/Voting.tsx
@@ -1,22 +1,31 @@
-import styled from "@emotion/styled";
-import { IonLabel, IonList, IonToggle } from "@ionic/react";
+import { IonActionSheet, IonLabel, IonList } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
-import { OVoteDisplayMode } from "../../../services/db";
+import { startCase } from "lodash";
+import { useState } from "react";
+import {
+  ActionSheetButton,
+  IonActionSheetCustomEvent,
+  OverlayEventDetail,
+} from "@ionic/core";
+import { OVoteDisplayMode, VoteDisplayMode } from "../../../services/db";
+import { ListHeader } from "./TextSize";
 import { setVoteDisplayMode } from "../settingsSlice";
 
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+const BUTTONS: ActionSheetButton<VoteDisplayMode>[] = Object.values(
+  OVoteDisplayMode
+).map(function (voteDisplayMode) {
+  return {
+    text: startCase(voteDisplayMode),
+    data: voteDisplayMode,
+  } as ActionSheetButton<VoteDisplayMode>;
+});
 
 export default function CollapsedByDefault() {
+  const [open, setOpen] = useState(false);
   const dispatch = useAppDispatch();
-  const { voteDisplayMode } = useAppSelector(
-    // this needs a better naming
-    (state) => state.settings.appearance.voting
+  const voteDisplayMode = useAppSelector(
+    (state) => state.settings.appearance.voting.voteDisplayMode
   );
 
   return (
@@ -25,19 +34,27 @@ export default function CollapsedByDefault() {
         <IonLabel>Voting</IonLabel>
       </ListHeader>
       <IonList inset>
-        <InsetIonItem>
-          <IonLabel>Show downvotes separately</IonLabel>
-          <IonToggle
-            checked={voteDisplayMode === OVoteDisplayMode.Separate}
-            onIonChange={(e) =>
-              dispatch(
-                setVoteDisplayMode(
-                  e.detail.checked
-                    ? OVoteDisplayMode.Separate
-                    : OVoteDisplayMode.SingleScore
-                )
-              )
-            }
+        <InsetIonItem button onClick={() => setOpen(true)}>
+          <IonLabel>Vote Display Mode</IonLabel>
+          <IonLabel slot="end" color="medium">
+            {startCase(voteDisplayMode)}
+          </IonLabel>
+          <IonActionSheet
+            cssClass="left-align-buttons"
+            isOpen={open}
+            onDidDismiss={() => setOpen(false)}
+            onWillDismiss={(
+              e: IonActionSheetCustomEvent<OverlayEventDetail<VoteDisplayMode>>
+            ) => {
+              if (e.detail.data) {
+                dispatch(setVoteDisplayMode(e.detail.data));
+              }
+            }}
+            header="Post Size"
+            buttons={BUTTONS.map((b) => ({
+              ...b,
+              role: voteDisplayMode === b.data ? "selected" : undefined,
+            }))}
           />
         </InsetIonItem>
       </IonList>

--- a/src/features/settings/appearance/posts/BlurNsfw.tsx
+++ b/src/features/settings/appearance/posts/BlurNsfw.tsx
@@ -1,58 +1,21 @@
-import { IonActionSheet, IonLabel } from "@ionic/react";
-import { useAppDispatch, useAppSelector } from "../../../../store";
-import { InsetIonItem } from "../../../user/Profile";
-import { startCase } from "lodash";
-import { useState } from "react";
-import {
-  ActionSheetButton,
-  IonActionSheetCustomEvent,
-  OverlayEventDetail,
-} from "@ionic/core";
+import { useAppSelector } from "../../../../store";
 import { OPostBlurNsfw, PostBlurNsfwType } from "../../../../services/db";
 import { setBlurNsfwState } from "../../settingsSlice";
-
-const BUTTONS: ActionSheetButton<PostBlurNsfwType>[] = Object.values(
-  OPostBlurNsfw
-).map(function (postBlurNsfw) {
-  return {
-    text: startCase(postBlurNsfw),
-    data: postBlurNsfw,
-  } as ActionSheetButton<PostBlurNsfwType>;
-});
+import SettingSelector from "../../shared/SettingSelector";
 
 export default function BlurNsfw() {
-  const [open, setOpen] = useState(false);
-
-  const dispatch = useAppDispatch();
   const nsfwBlurred = useAppSelector(
     (state) => state.settings.appearance.posts.blurNsfw
   );
 
+  const BlurSelector = SettingSelector<PostBlurNsfwType>;
+
   return (
-    <>
-      <InsetIonItem button onClick={() => setOpen(true)}>
-        <IonLabel>Blur NSFW</IonLabel>
-        <IonLabel slot="end" color="medium">
-          {startCase(nsfwBlurred)}
-        </IonLabel>
-        <IonActionSheet
-          cssClass="left-align-buttons"
-          isOpen={open}
-          onDidDismiss={() => setOpen(false)}
-          onWillDismiss={(
-            e: IonActionSheetCustomEvent<OverlayEventDetail<PostBlurNsfwType>>
-          ) => {
-            if (e.detail.data) {
-              dispatch(setBlurNsfwState(e.detail.data));
-            }
-          }}
-          header="Blur NSFW"
-          buttons={BUTTONS.map((b) => ({
-            ...b,
-            role: nsfwBlurred === b.data ? "selected" : undefined,
-          }))}
-        />
-      </InsetIonItem>
-    </>
+    <BlurSelector
+      title="Blur NSFW"
+      selected={nsfwBlurred}
+      setSelected={setBlurNsfwState}
+      options={OPostBlurNsfw}
+    />
   );
 }

--- a/src/features/settings/appearance/posts/PostSize.tsx
+++ b/src/features/settings/appearance/posts/PostSize.tsx
@@ -1,61 +1,24 @@
 import {
-  ActionSheetButton,
-  IonActionSheetCustomEvent,
-  OverlayEventDetail,
-} from "@ionic/core";
-import {
   OPostAppearanceType,
   PostAppearanceType,
   setPostAppearance,
 } from "../../settingsSlice";
-import { startCase } from "lodash";
-import { useState } from "react";
-import { useAppDispatch, useAppSelector } from "../../../../store";
-import { InsetIonItem } from "../../../user/Profile";
-import { IonActionSheet, IonLabel } from "@ionic/react";
-
-const BUTTONS: ActionSheetButton<PostAppearanceType>[] = Object.values(
-  OPostAppearanceType
-).map(function (postAppearanceType) {
-  return {
-    text: startCase(postAppearanceType),
-    data: postAppearanceType,
-  } as ActionSheetButton<PostAppearanceType>;
-});
+import { useAppSelector } from "../../../../store";
+import SettingSelector from "../../shared/SettingSelector";
 
 export default function PostSize() {
-  const [open, setOpen] = useState(false);
-
-  const dispatch = useAppDispatch();
   const postsAppearanceType = useAppSelector(
     (state) => state.settings.appearance.posts.type
   );
 
+  const PostSizeSelector = SettingSelector<PostAppearanceType>;
+
   return (
-    <>
-      <InsetIonItem button onClick={() => setOpen(true)}>
-        <IonLabel>Post Size</IonLabel>
-        <IonLabel slot="end" color="medium">
-          {startCase(postsAppearanceType)}
-        </IonLabel>
-        <IonActionSheet
-          cssClass="left-align-buttons"
-          isOpen={open}
-          onDidDismiss={() => setOpen(false)}
-          onWillDismiss={(
-            e: IonActionSheetCustomEvent<OverlayEventDetail<PostAppearanceType>>
-          ) => {
-            if (e.detail.data) {
-              dispatch(setPostAppearance(e.detail.data));
-            }
-          }}
-          header="Post Size"
-          buttons={BUTTONS.map((b) => ({
-            ...b,
-            role: postsAppearanceType === b.data ? "selected" : undefined,
-          }))}
-        />
-      </InsetIonItem>
-    </>
+    <PostSizeSelector
+      title="Post Size"
+      selected={postsAppearanceType}
+      setSelected={setPostAppearance}
+      options={OPostAppearanceType}
+    />
   );
 }

--- a/src/features/settings/appearance/posts/Posts.tsx
+++ b/src/features/settings/appearance/posts/Posts.tsx
@@ -1,5 +1,5 @@
 import { IonLabel, IonList } from "@ionic/react";
-import { ListHeader } from "../TextSize";
+import { ListHeader } from "../../shared/formatting";
 import BlurNsfw from "./BlurNsfw";
 import PostSize from "./PostSize";
 

--- a/src/features/settings/appearance/system/System.tsx
+++ b/src/features/settings/appearance/system/System.tsx
@@ -1,6 +1,6 @@
 import { IonLabel, IonList } from "@ionic/react";
 import DarkMode from "./DarkMode";
-import { ListHeader } from "../TextSize";
+import { ListHeader } from "../../shared/formatting";
 import DeviceMode from "./DeviceMode";
 import { useAppSelector } from "../../../../store";
 import UserDarkMode from "./UserDarkMode";

--- a/src/features/settings/appearance/system/UserDarkMode.tsx
+++ b/src/features/settings/appearance/system/UserDarkMode.tsx
@@ -1,15 +1,8 @@
-import styled from "@emotion/styled";
 import { IonLabel, IonList, IonRadio, IonRadioGroup } from "@ionic/react";
 import { InsetIonItem } from "../../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../../store";
 import { setUserDarkMode } from "../../settingsSlice";
-
-const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../../shared/formatting";
 
 export default function UserDarkMode() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/blocks/BlockedCommunities.tsx
+++ b/src/features/settings/blocks/BlockedCommunities.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   IonItemOption,
   IonItemOptions,
@@ -13,13 +12,7 @@ import { useState } from "react";
 import { getHandle } from "../../../helpers/lemmy";
 import { CommunityBlockView } from "lemmy-js-client";
 import { blockCommunity } from "../../community/communitySlice";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../shared/formatting";
 
 export default function BlockedCommunities() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/blocks/BlockedUsers.tsx
+++ b/src/features/settings/blocks/BlockedUsers.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   IonItemOption,
   IonItemOptions,
@@ -13,13 +12,7 @@ import { useState } from "react";
 import { getHandle } from "../../../helpers/lemmy";
 import { PersonBlockView } from "lemmy-js-client";
 import { blockUser } from "../../user/userSlice";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../shared/formatting";
 
 export default function BlockedUsers() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/blocks/FilterNsfw.tsx
+++ b/src/features/settings/blocks/FilterNsfw.tsx
@@ -1,16 +1,9 @@
-import styled from "@emotion/styled";
 import { IonLabel, IonList, IonLoading, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { localUserSelector, showNsfw } from "../../auth/authSlice";
 import { useState } from "react";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
+import { ListHeader } from "../shared/formatting";
 
 export default function FilterNsfw() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/general/comments/CollapsedByDefault.tsx
+++ b/src/features/settings/general/comments/CollapsedByDefault.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { IonLabel, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../../store";
@@ -6,13 +5,6 @@ import {
   OCommentThreadCollapse,
   setCommentsCollapsed,
 } from "../../settingsSlice";
-
-export const ListHeader = styled.div`
-  font-size: 0.8em;
-  margin: 32px 0 -8px 32px;
-  text-transform: uppercase;
-  color: var(--ion-color-medium);
-`;
 
 export default function CollapsedByDefault() {
   const dispatch = useAppDispatch();

--- a/src/features/settings/general/comments/Comments.tsx
+++ b/src/features/settings/general/comments/Comments.tsx
@@ -1,8 +1,7 @@
 import { IonLabel, IonList } from "@ionic/react";
-import CollapsedByDefault, {
-  ListHeader,
-} from "../../general/comments/CollapsedByDefault";
+import CollapsedByDefault from "../../general/comments/CollapsedByDefault";
 import DefaultSort from "./DefaultSort";
+import { ListHeader } from "../../shared/formatting";
 
 export default function Comments() {
   return (

--- a/src/features/settings/general/posts/Posts.tsx
+++ b/src/features/settings/general/posts/Posts.tsx
@@ -1,6 +1,6 @@
 import { IonLabel, IonList } from "@ionic/react";
-import { ListHeader } from "../comments/CollapsedByDefault";
 import { InsetIonItem } from "../../../user/Profile";
+import { ListHeader } from "../../shared/formatting";
 
 export default function Posts() {
   return (

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -107,7 +107,7 @@ const initialState: SettingsState = {
       showVotingButtons: true,
     },
     voting: {
-      voteDisplayMode: OVoteDisplayMode.SingleScore,
+      voteDisplayMode: OVoteDisplayMode.Total,
     },
     dark: {
       usingSystemDarkMode: true,

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -21,6 +21,8 @@ import {
   OCommentDefaultSort,
   InstanceUrlDisplayMode,
   OInstanceUrlDisplayMode,
+  VoteDisplayMode,
+  OVoteDisplayMode,
 } from "../../services/db";
 import { get, set } from "./storage";
 import { Mode } from "@ionic/core";
@@ -51,6 +53,9 @@ interface SettingsState {
     compact: {
       thumbnailsPosition: CompactThumbnailPositionType;
       showVotingButtons: boolean;
+    };
+    voting: {
+      voteDisplayMode: VoteDisplayMode;
     };
     dark: {
       usingSystemDarkMode: boolean;
@@ -100,6 +105,9 @@ const initialState: SettingsState = {
     compact: {
       thumbnailsPosition: OCompactThumbnailPositionType.Left,
       showVotingButtons: true,
+    },
+    voting: {
+      voteDisplayMode: OVoteDisplayMode.SingleScore,
     },
     dark: {
       usingSystemDarkMode: true,
@@ -199,6 +207,10 @@ export const appearanceSlice = createSlice({
       state.appearance.compact.thumbnailsPosition = action.payload;
       db.setSetting("compact_thumbnail_position_type", action.payload);
     },
+    setVoteDisplayMode(state, action: PayloadAction<VoteDisplayMode>) {
+      state.appearance.voting.voteDisplayMode = action.payload;
+      db.setSetting("vote_display_mode", action.payload);
+    },
     setUserDarkMode(state, action: PayloadAction<boolean>) {
       state.appearance.dark.userDarkMode = action.payload;
       set(LOCALSTORAGE_KEYS.DARK.USER_MODE, action.payload);
@@ -291,6 +303,7 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
       const compact_show_voting_buttons = await db.getSetting(
         "compact_show_voting_buttons"
       );
+      const vote_display_mode = await db.getSetting("vote_display_mode");
       const default_comment_sort = await db.getSetting("default_comment_sort");
       const disable_marking_posts_read = await db.getSetting(
         "disable_marking_posts_read"
@@ -321,6 +334,11 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
             showVotingButtons:
               compact_show_voting_buttons ??
               initialState.appearance.compact.showVotingButtons,
+          },
+          voting: {
+            voteDisplayMode:
+              vote_display_mode ??
+              initialState.appearance.voting.voteDisplayMode,
           },
         },
         general: {
@@ -365,6 +383,7 @@ export const {
   setPostAppearance,
   setThumbnailPosition,
   setShowVotingButtons,
+  setVoteDisplayMode,
   setUserDarkMode,
   setUseSystemDarkMode,
   setDeviceMode,

--- a/src/features/settings/shared/SettingSelector.tsx
+++ b/src/features/settings/shared/SettingSelector.tsx
@@ -1,0 +1,65 @@
+import styled from "@emotion/styled";
+import {
+  ActionSheetButton,
+  IonActionSheetCustomEvent,
+  OverlayEventDetail,
+} from "@ionic/core";
+import { IonActionSheet, IonItem, IonLabel } from "@ionic/react";
+import { Dictionary, startCase } from "lodash";
+import { useState } from "react";
+import { useAppDispatch } from "../../../store";
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
+
+const InsetIonItem = styled(IonItem)`
+  --background: var(--ion-tab-bar-background, var(--ion-color-step-50, #fff));
+`;
+
+export interface SettingSelectorProps<T> {
+  title: string;
+  selected: T;
+  set_selected: ActionCreatorWithPayload<T>;
+  options: Dictionary<string>;
+}
+
+export default function SettingSelector<T extends string>({
+  title,
+  selected,
+  set_selected,
+  options,
+}: SettingSelectorProps<T>) {
+  const [open, setOpen] = useState(false);
+  const dispatch = useAppDispatch();
+
+  const buttons: ActionSheetButton<T>[] = Object.values(options).map(function (
+    v
+  ) {
+    return {
+      text: startCase(v),
+      data: v,
+    } as ActionSheetButton<T>;
+  });
+
+  return (
+    <InsetIonItem button onClick={() => setOpen(true)}>
+      <IonLabel>{title}</IonLabel>
+      <IonLabel slot="end" color="medium">
+        {startCase(selected)}
+      </IonLabel>
+      <IonActionSheet
+        cssClass="left-align-buttons"
+        isOpen={open}
+        onDidDismiss={() => setOpen(false)}
+        onWillDismiss={(e: IonActionSheetCustomEvent<OverlayEventDetail>) => {
+          if (e.detail.data) {
+            dispatch(set_selected(e.detail.data));
+          }
+        }}
+        header={title}
+        buttons={buttons.map((b) => ({
+          ...b,
+          role: selected === b.data ? "selected" : undefined,
+        }))}
+      />
+    </InsetIonItem>
+  );
+}

--- a/src/features/settings/shared/SettingSelector.tsx
+++ b/src/features/settings/shared/SettingSelector.tsx
@@ -17,14 +17,14 @@ const InsetIonItem = styled(IonItem)`
 export interface SettingSelectorProps<T> {
   title: string;
   selected: T;
-  set_selected: ActionCreatorWithPayload<T>;
+  setSelected: ActionCreatorWithPayload<T>;
   options: Dictionary<string>;
 }
 
 export default function SettingSelector<T extends string>({
   title,
   selected,
-  set_selected,
+  setSelected,
   options,
 }: SettingSelectorProps<T>) {
   const [open, setOpen] = useState(false);
@@ -51,7 +51,7 @@ export default function SettingSelector<T extends string>({
         onDidDismiss={() => setOpen(false)}
         onWillDismiss={(e: IonActionSheetCustomEvent<OverlayEventDetail>) => {
           if (e.detail.data) {
-            dispatch(set_selected(e.detail.data));
+            dispatch(setSelected(e.detail.data));
           }
         }}
         header={title}

--- a/src/features/settings/shared/SettingSelector.tsx
+++ b/src/features/settings/shared/SettingSelector.tsx
@@ -8,7 +8,6 @@ import { IonActionSheet, IonItem, IonLabel } from "@ionic/react";
 import { Dictionary, startCase } from "lodash";
 import { useState } from "react";
 import { useAppDispatch } from "../../../store";
-import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 
 const InsetIonItem = styled(IonItem)`
   --background: var(--ion-tab-bar-background, var(--ion-color-step-50, #fff));
@@ -17,7 +16,8 @@ const InsetIonItem = styled(IonItem)`
 export interface SettingSelectorProps<T> {
   title: string;
   selected: T;
-  setSelected: ActionCreatorWithPayload<T>;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  setSelected: Function;
   options: Dictionary<string>;
 }
 

--- a/src/features/settings/shared/SettingSelector.tsx
+++ b/src/features/settings/shared/SettingSelector.tsx
@@ -7,7 +7,7 @@ import {
 import { IonActionSheet, IonItem, IonLabel } from "@ionic/react";
 import { Dictionary, startCase } from "lodash";
 import { useState } from "react";
-import { useAppDispatch } from "../../../store";
+import { Dispatchable, useAppDispatch } from "../../../store";
 
 const InsetIonItem = styled(IonItem)`
   --background: var(--ion-tab-bar-background, var(--ion-color-step-50, #fff));
@@ -16,8 +16,7 @@ const InsetIonItem = styled(IonItem)`
 export interface SettingSelectorProps<T> {
   title: string;
   selected: T;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  setSelected: Function;
+  setSelected: Dispatchable<T>;
   options: Dictionary<string>;
 }
 
@@ -49,7 +48,9 @@ export default function SettingSelector<T extends string>({
         cssClass="left-align-buttons"
         isOpen={open}
         onDidDismiss={() => setOpen(false)}
-        onWillDismiss={(e: IonActionSheetCustomEvent<OverlayEventDetail>) => {
+        onWillDismiss={(
+          e: IonActionSheetCustomEvent<OverlayEventDetail<T>>
+        ) => {
           if (e.detail.data) {
             dispatch(setSelected(e.detail.data));
           }

--- a/src/features/settings/shared/formatting.ts
+++ b/src/features/settings/shared/formatting.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const ListHeader = styled.div`
+  font-size: 0.8em;
+  margin: 32px 0 -8px 32px;
+  text-transform: uppercase;
+  color: var(--ion-color-medium);
+`;

--- a/src/helpers/vote.ts
+++ b/src/helpers/vote.ts
@@ -7,5 +7,19 @@ export function calculateCurrentVotesCount(
 ) {
   const id = "comment" in item ? item.comment.id : item.post.id;
 
-  return item.counts.score - (item.my_vote ?? 0) + (votesById[id] ?? 0);
+  const score = item.counts.score - (item.my_vote ?? 0) + (votesById[id] ?? 0);
+  const upvotes =
+    item.counts.upvotes -
+    (item.my_vote === 1 ? 1 : 0) +
+    (votesById[id] === 1 ? 1 : 0);
+  const downvotes =
+    item.counts.downvotes -
+    (item.my_vote === -1 ? 1 : 0) +
+    (votesById[id] === -1 ? 1 : 0);
+
+  return {
+    score: score,
+    upvotes: upvotes,
+    downvotes: downvotes,
+  };
 }

--- a/src/helpers/vote.ts
+++ b/src/helpers/vote.ts
@@ -1,13 +1,20 @@
 import { Dictionary } from "@reduxjs/toolkit";
 import { CommentView, PostView } from "lemmy-js-client";
 
-export function calculateCurrentVotesCount(
+export function calculateNetVoteCount(
+  item: PostView | CommentView,
+  votesById: Dictionary<0 | 1 | -1>
+) {
+  const id = "comment" in item ? item.comment.id : item.post.id;
+  return item.counts.score - (item.my_vote ?? 0) + (votesById[id] ?? 0);
+}
+
+export function calculateVoteCounts(
   item: PostView | CommentView,
   votesById: Dictionary<0 | 1 | -1>
 ) {
   const id = "comment" in item ? item.comment.id : item.post.id;
 
-  const score = item.counts.score - (item.my_vote ?? 0) + (votesById[id] ?? 0);
   const upvotes =
     item.counts.upvotes -
     (item.my_vote === 1 ? 1 : 0) +
@@ -17,9 +24,5 @@ export function calculateCurrentVotesCount(
     (item.my_vote === -1 ? 1 : 0) +
     (votesById[id] === -1 ? 1 : 0);
 
-  return {
-    score: score,
-    upvotes: upvotes,
-    downvotes: downvotes,
-  };
+  return { upvotes, downvotes };
 }

--- a/src/helpers/vote.ts
+++ b/src/helpers/vote.ts
@@ -1,7 +1,7 @@
 import { Dictionary } from "@reduxjs/toolkit";
 import { CommentView, PostView } from "lemmy-js-client";
 
-export function calculateNetVoteCount(
+export function calculateTotalScore(
   item: PostView | CommentView,
   votesById: Dictionary<0 | 1 | -1>
 ) {
@@ -9,7 +9,7 @@ export function calculateNetVoteCount(
   return item.counts.score - (item.my_vote ?? 0) + (votesById[id] ?? 0);
 }
 
-export function calculateVoteCounts(
+export function calculateSeparateScore(
   item: PostView | CommentView,
   votesById: Dictionary<0 | 1 | -1>
 ) {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -58,8 +58,9 @@ export type InstanceUrlDisplayMode =
   (typeof OInstanceUrlDisplayMode)[keyof typeof OInstanceUrlDisplayMode];
 
 export const OVoteDisplayMode = {
+  NoScores: "none",
   SingleScore: "single-score",
-  Separate: "separate",
+  SeparateScores: "separate",
 } as const;
 
 export type VoteDisplayMode =

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -57,9 +57,18 @@ export const OInstanceUrlDisplayMode = {
 export type InstanceUrlDisplayMode =
   (typeof OInstanceUrlDisplayMode)[keyof typeof OInstanceUrlDisplayMode];
 
+export const OVoteDisplayMode = {
+  SingleScore: "single-score",
+  Separate: "separate",
+} as const;
+
+export type VoteDisplayMode =
+  (typeof OVoteDisplayMode)[keyof typeof OVoteDisplayMode];
+
 export type SettingValueTypes = {
   collapse_comment_threads: CommentThreadCollapse;
   user_instance_url_display: InstanceUrlDisplayMode;
+  vote_display_mode: VoteDisplayMode;
   post_appearance_type: PostAppearanceType;
   compact_thumbnail_position_type: CompactThumbnailPositionType;
   compact_show_voting_buttons: boolean;

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -58,9 +58,20 @@ export type InstanceUrlDisplayMode =
   (typeof OInstanceUrlDisplayMode)[keyof typeof OInstanceUrlDisplayMode];
 
 export const OVoteDisplayMode = {
-  NoScores: "hide",
-  SingleScore: "total",
-  SeparateScores: "separate",
+  /**
+   * Show total score (upvotes + downvotes)
+   */
+  Total: "total",
+
+  /**
+   * Show upvotes and downvotes separately
+   */
+  Separate: "separate",
+
+  /**
+   * Hide scores
+   */
+  Hide: "hide",
 } as const;
 
 export type VoteDisplayMode =

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -58,8 +58,8 @@ export type InstanceUrlDisplayMode =
   (typeof OInstanceUrlDisplayMode)[keyof typeof OInstanceUrlDisplayMode];
 
 export const OVoteDisplayMode = {
-  NoScores: "none",
-  SingleScore: "single-score",
+  NoScores: "hide",
+  SingleScore: "total",
   SeparateScores: "separate",
 } as const;
 

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect } from "react";
-import { configureStore } from "@reduxjs/toolkit";
+import { ActionCreatorWithPayload, configureStore } from "@reduxjs/toolkit";
 import postSlice from "./features/post/postSlice";
 import {
   Provider,
@@ -35,6 +35,10 @@ export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export type Dispatchable<T> =
+  | ((val: T) => (dispatch: AppDispatch, getState: () => RootState) => void)
+  | ActionCreatorWithPayload<T>;
 
 export default store;
 


### PR DESCRIPTION
Fixes #170 and fixes #135. When the setting is in the default mode, it should work the same as before.

<img width="200" alt="upvote" src="https://github.com/aeharding/wefwef/assets/20521763/c5e70cfb-841a-4fd0-bbff-95d6e5e77aae"><br />
<img width="200" alt="downvote" src="https://github.com/aeharding/wefwef/assets/20521763/2acfb69e-381e-425a-8823-e39f5a459a9c"><br />
<img width="150" alt="no votes" src="https://github.com/aeharding/wefwef/assets/20521763/23400659-249c-4200-95cb-001ba1bb4320"><br />
<img width="433" alt="selector" src="https://github.com/aeharding/wefwef/assets/20521763/ae7e0cc4-6d96-4f66-b7f1-59556f53a8a6">