### PR TITLE
Allow sharing/previewing links and embeds in ios

### DIFF
--- a/src/features/post/shared/Embed.tsx
+++ b/src/features/post/shared/Embed.tsx
@@ -15,6 +15,7 @@ const Container = styled.a`
 
   color: inherit;
   text-decoration: none;
+  -webkit-touch-callout: default;
 `;
 
 const Img = styled.img<{ blur: boolean }>`

--- a/src/features/shared/markdown/LinkInterceptor.tsx
+++ b/src/features/shared/markdown/LinkInterceptor.tsx
@@ -2,13 +2,16 @@ import { LinkHTMLAttributes, MouseEvent, useCallback } from "react";
 import { useAppSelector } from "../../../store";
 import { useIonRouter } from "@ionic/react";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
+import styled from "@emotion/styled";
 
 const COMMUNITY_RELATIVE_URL =
   /^\/c\/([a-zA-Z0-9._%+-]+(@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})?)\/?$/;
 
-export default function LinkInterceptor(
-  props: LinkHTMLAttributes<HTMLAnchorElement>
-) {
+const LinkInterceptor = styled(LinkInterceptorUnstyled)`
+  -webkit-touch-callout: default;
+`;
+
+function LinkInterceptorUnstyled(props: LinkHTMLAttributes<HTMLAnchorElement>) {
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance
   );
@@ -63,3 +66,5 @@ function matchLemmyCommunity(
   }
   return null;
 }
+
+export default LinkInterceptor;


### PR DESCRIPTION
Similar to #226 it allows the web-preview/sharing for both embeds and the markdown links.
Same as the last PR - I don't think this interferes with any existing gestures.
Also helps #69

I wasn't 100% sure if the link interceptor is where you wanted this to be, or if I did it in the style you prefer.

https://github.com/aeharding/wefwef/assets/1349689/975c3492-f721-4af8-bc16-db798369020e

