### PR TITLE
Fix invalidated tokens not being cleared from storage

### DIFF
--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -197,14 +197,21 @@ export const login =
 export const getSite =
   () => async (dispatch: AppDispatch, getState: () => RootState) => {
     const jwtPayload = jwtPayloadSelector(getState());
+    const handle = handleSelector(getState());
 
-    if (!jwtPayload) return;
+    if (!jwtPayload || !handle) return;
 
     const { iss } = jwtPayload;
 
     const details = await getClient(iss).getSite({
       auth: jwtSelector(getState()),
     });
+
+    // JWT was revoked or invalid, log out user
+    if (!details.my_user) {
+      await dispatch(logoutAccount(handle));
+      return;
+    }
 
     dispatch(updateUserDetails(details));
   };


### PR DESCRIPTION
This is an emergency hotfix related to lemmy.world revoking login tokens.

Without this fix, users will appear logged in but not actually be logged in, since they have an invalid token.