### PR TITLE
feat: show unread comments/mentions/msgs in Inbox

### DIFF
--- a/src/pages/inbox/BoxesPage.tsx
+++ b/src/pages/inbox/BoxesPage.tsx
@@ -28,6 +28,13 @@ import { getInboxCounts } from "../../features/inbox/inboxSlice";
 import useClient from "../../helpers/useClient";
 import { useAppDispatch, useAppSelector } from "../../store";
 
+const UnreadBubble: FC<{ count: number }> = ({ count }) =>
+  count ? (
+    <IonBadge color="danger" slot="end">
+      {count}
+    </IonBadge>
+  ) : null;
+
 export default function BoxesPage() {
   const client = useClient();
   const jwt = useAppSelector(jwtSelector);
@@ -39,13 +46,6 @@ export default function BoxesPage() {
   } = useAppSelector((state) => state.inbox.counts);
   const [unreadPostReplies, setUnreadPostReplies] = useState(0);
   const [unreadCountsResolved, setUnreadCountsResolved] = useState(false);
-
-  const UnreadBubble: FC<{ count: number }> = ({ count }) =>
-    unreadCountsResolved && count ? (
-      <IonBadge color="danger" slot="end">
-        {count}
-      </IonBadge>
-    ) : null;
 
   const getUnreadPostReplyCount = async (): Promise<void> => {
     if (!jwt) return;
@@ -114,7 +114,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={albumsOutline} color="primary" />
             <SettingLabel>Post Replies</SettingLabel>
-            <UnreadBubble count={unreadPostReplies} />
+            {unreadCountsResolved && <UnreadBubble count={unreadPostReplies} />}
           </InsetIonItem>
           <InsetIonItem
             routerLink="/inbox/comment-replies"
@@ -122,7 +122,9 @@ export default function BoxesPage() {
           >
             <IonIcon icon={chatbubbleOutline} color="primary" />
             <SettingLabel>Comment Replies</SettingLabel>
-            <UnreadBubble count={unreadReplies - unreadPostReplies} />
+            {unreadCountsResolved && (
+              <UnreadBubble count={unreadReplies - unreadPostReplies} />
+            )}
           </InsetIonItem>
           <InsetIonItem
             routerLink="/inbox/mentions"
@@ -130,7 +132,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={personCircleOutline} color="primary" />
             <SettingLabel>Mentions</SettingLabel>
-            <UnreadBubble count={unreadMentions} />
+            {unreadCountsResolved && <UnreadBubble count={unreadMentions} />}
           </InsetIonItem>
         </IonList>
 
@@ -141,7 +143,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={mail} color="primary" />
             <SettingLabel>Messages</SettingLabel>
-            <UnreadBubble count={unreadMessages} />
+            {unreadCountsResolved && <UnreadBubble count={unreadMessages} />}
           </InsetIonItem>
         </IonList>
       </AppContent>

--- a/src/pages/inbox/BoxesPage.tsx
+++ b/src/pages/inbox/BoxesPage.tsx
@@ -122,7 +122,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={chatbubbleOutline} color="primary" />
             <SettingLabel>Comment Replies</SettingLabel>
-            <UnreadBubble count={unreadReplies} />
+            <UnreadBubble count={unreadReplies - unreadPostReplies} />
           </InsetIonItem>
           <InsetIonItem
             routerLink="/inbox/mentions"

--- a/src/pages/inbox/BoxesPage.tsx
+++ b/src/pages/inbox/BoxesPage.tsx
@@ -1,4 +1,6 @@
+import { type FC } from "react";
 import {
+  IonBadge,
   IonHeader,
   IonIcon,
   IonList,
@@ -21,8 +23,22 @@ import { useAppDispatch } from "../../store";
 import { getInboxCounts } from "../../features/inbox/inboxSlice";
 import { MouseEvent, useContext } from "react";
 import { PageContext } from "../../features/auth/PageContext";
+import { useAppSelector } from "../../store";
+
+const UnreadBubble: FC<{ count: number }> = ({ count }) =>
+  count ? (
+    <IonBadge color="danger" slot="end">
+      {count}
+    </IonBadge>
+  ) : null;
 
 export default function BoxesPage() {
+  const {
+    mentions: unreadMentions,
+    messages: unreadMessages,
+    replies: unreadReplies,
+  } = useAppSelector((state) => state.inbox.counts);
+
   const dispatch = useAppDispatch();
 
   const { presentLoginIfNeeded } = useContext(PageContext);
@@ -77,6 +93,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={chatbubbleOutline} color="primary" />
             <SettingLabel>Comment Replies</SettingLabel>
+            <UnreadBubble count={unreadReplies} />
           </InsetIonItem>
           <InsetIonItem
             routerLink="/inbox/mentions"
@@ -84,6 +101,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={personCircleOutline} color="primary" />
             <SettingLabel>Mentions</SettingLabel>
+            <UnreadBubble count={unreadMentions} />
           </InsetIonItem>
         </IonList>
 
@@ -94,6 +112,7 @@ export default function BoxesPage() {
           >
             <IonIcon icon={mail} color="primary" />
             <SettingLabel>Messages</SettingLabel>
+            <UnreadBubble count={unreadMessages} />
           </InsetIonItem>
         </IonList>
       </AppContent>


### PR DESCRIPTION
Closes https://github.com/aeharding/voyager/issues/325.

@aeharding/@rsammelson: Unfortunately, the `/unread_count` endpoint on the lemmy back-end only includes [_Comment_ Replies, Mentions, and Private Messages](https://github.com/LemmyNet/lemmy/blob/1d38aad9d3d51ef606074d5b49a8030c49dd0e9e/crates/api/src/local_user/notifications/unread_count.rs#L23-L34)—there's no straight-forward way to get a count for Post Replies/Comments.

I went ahead and added some simple logic to determine whether a 'reply' is a POST reply or a COMMENT reply, as initially created by @aeharding in:

https://github.com/aeharding/voyager/blob/c64e84af15f563d998fbcd9bcb344d3a8222859c/src/features/inbox/InboxItem.tsx#L136-L169 

Not super elegant (ideally, this would be handled on the BE by Lemmy, but until then this will suffice). Screengrab of what this looks like:

https://github.com/aeharding/voyager/assets/13839643/381f0bea-9e15-4f02-b36c-3a6dc4caadd3

Because of the additional request that happens when the view switches to `Inbox`, there's a slight delay between showing the Bubbles—I've played with having the Bubbles be there when the view loads (use the counts from `state.inbox.counts`) and have the counts update as an alternative (code not part of PR). This looks like:

https://github.com/aeharding/voyager/assets/13839643/99f29c2e-7116-450f-9113-bbf65fcf7d36

---

I'm personally leaning toward the 'update the counts' implementation, but I'll let you (@aeharding and/or @rsammelson) make the call of what would be a better UX. Let me know.
