### PR TITLE
Fix post "more actions" menu cancel button style

### DIFF
--- a/src/features/post/shared/MoreActions.tsx
+++ b/src/features/post/shared/MoreActions.tsx
@@ -144,6 +144,7 @@ export default function MoreActions({
         {
           text: "Cancel",
           data: "cancel",
+          role: "cancel",
         },
       ].filter(notEmpty),
     [isHidden, myVote, mySaved, post.community, post.creator, onFeed, isMyPost]


### PR DESCRIPTION
Cancel button no longer looks like a cancel button, it appears to be an accidental change introduced in 9514b46bb72acc65.

<img width="350" src="https://github.com/aeharding/voyager/assets/20521763/05cb5b8d-8368-4fb5-ab61-8347077ece00">
