### PR TITLE
Fix/Scroll to top after top > time selection

### DIFF
--- a/src/features/feed/PostSort.tsx
+++ b/src/features/feed/PostSort.tsx
@@ -110,6 +110,7 @@ export default function PostSort() {
         ) => {
           if (e.detail.data) {
             dispatch(updateSortType(e.detail.data));
+            scrollUpIfNeeded(activePage, 0, "auto");
           }
         }}
         header="Sort by Top for..."


### PR DESCRIPTION
Post sort scroll change is working when sort change isn't in the nested top menu.

This PR fixes top > time sort change scroll

Before:

https://youtube.com/shorts/b-EXfg5Q7Ko

after:

https://youtu.be/_idc8nE4Igs