### PR TITLE
Change Report terminology from Custom Response to Report

### DIFF
--- a/src/features/report/Report.tsx
+++ b/src/features/report/Report.tsx
@@ -118,7 +118,7 @@ export const Report = forwardRef<ReportHandle>(function Report(_, ref) {
             data: "Spam or Abuse",
           },
           {
-            text: "Custom Response",
+            text: "Custom Report",
             data: "other",
           },
           {


### PR DESCRIPTION
Changed the terminology of Reports from "Custom Response" to "Custom Report", as “Custom Reponse” just doesn’t sound right to me, and “Custom Report” just makes more sense.