### PR TITLE
[bugfix] all posts in nsfw communities should be nsfw

### DIFF
--- a/src/features/labels/Nsfw.tsx
+++ b/src/features/labels/Nsfw.tsx
@@ -21,7 +21,7 @@ export default function Nsfw() {
 const NSFW_INSTANCES = ["lemmynsfw.com"];
 
 export function isNsfw(post: PostView): boolean {
-  if (post.post.nsfw) return true;
+  if (post.post.nsfw || post.community.nsfw) return true;
 
   if (NSFW_INSTANCES.includes(getItemActorName(post.community))) return true;
 


### PR DESCRIPTION
The community nsfw doesn't force the post nsfw to be `true`. This results in images from those communities being unblurred, which doesn't match desktop site functionality