### PR TITLE
Stop Remove Account icon to be cropped

### DIFF
--- a/src/features/auth/Account.tsx
+++ b/src/features/auth/Account.tsx
@@ -16,7 +16,6 @@ import styled from "@emotion/styled";
 
 const RemoveIcon = styled(IonIcon)`
   position: relative;
-  font-size: 1.5rem;
 
   &:after {
     z-index: -1;
@@ -57,7 +56,7 @@ export default function Account({ editing, account }: AccountProps) {
               slidingRef.current?.open("end");
             }}
           >
-            <RemoveIcon icon={removeCircle} color="danger" />
+            <RemoveIcon icon={removeCircle} color="danger" slot="icon-only" />
           </IonButton>
         )}
         <IonRadio value={account.handle}>{account.handle}</IonRadio>


### PR DESCRIPTION
Fixes #403
The icon is now the standard size for Ionic for icon-only buttons. It's minutely smaller than before at the normal font size (23.4 x 23.4 vs 24 x 24).