### PR TITLE
feat: Show selected "Top" interval in post sorting menu

### DIFF
--- a/src/features/feed/PostSort.tsx
+++ b/src/features/feed/PostSort.tsx
@@ -95,6 +95,10 @@ export default function PostSort() {
         buttons={BUTTONS.map((b) => ({
           ...b,
           cssClass: b.data === "Top" ? "detail" : undefined,
+          text: 
+            (sort.startsWith("Top") && b.data === "Top") 
+              ? `${b.text} (${formatTopLabel(sort)})`
+              : b.text,
           role:
             sort === b.data || (sort.startsWith("Top") && b.data === "Top")
               ? "selected"

--- a/src/features/feed/PostSort.tsx
+++ b/src/features/feed/PostSort.tsx
@@ -95,8 +95,8 @@ export default function PostSort() {
         buttons={BUTTONS.map((b) => ({
           ...b,
           cssClass: b.data === "Top" ? "detail" : undefined,
-          text: 
-            (sort.startsWith("Top") && b.data === "Top") 
+          text:
+            sort.startsWith("Top") && b.data === "Top"
               ? `${b.text} (${formatTopLabel(sort)})`
               : b.text,
           role:

--- a/src/features/feed/PostSort.tsx
+++ b/src/features/feed/PostSort.tsx
@@ -96,7 +96,7 @@ export default function PostSort() {
           ...b,
           cssClass: b.data === "Top" ? "detail" : undefined,
           text:
-            sort.startsWith("Top") && b.data === "Top"
+            isTopSort(sort) && b.data === "Top"
               ? `${b.text} (${formatTopLabel(sort)})`
               : b.text,
           role:
@@ -174,4 +174,8 @@ function formatTopLabel(sort: (typeof TOP_POST_SORTS)[number]): string {
     case "TopAll":
       return "All Time";
   }
+}
+
+function isTopSort(sort: SortType): sort is (typeof TOP_POST_SORTS)[number] {
+  return (TOP_POST_SORTS as unknown as string[]).includes(sort as string);
 }


### PR DESCRIPTION
This pull request enhances the `PostSort` component by adding the currently selected Top interval (e.g. Hour, Week, All Time) in the post sorting menu. When an alternative sort option is selected (e.g. Hot, Most Comments), no interval suffix is displayed.

**Before:**
![Before](https://github.com/aeharding/voyager/assets/57397330/a60a0f0d-9db6-4685-8223-90e4c033ccb7)

**After:**
![After](https://github.com/aeharding/voyager/assets/57397330/01f960ce-6218-4748-aee5-7139293b9b5a)

