### PR TITLE
Show Imgur and other videos in the Feed and the Post view

### DIFF
--- a/src/features/post/detail/PostDetail.tsx
+++ b/src/features/post/detail/PostDetail.tsx
@@ -170,11 +170,13 @@ export default function PostDetail({
   function renderImage() {
     if (!post) return;
 
-    if (post.post.url) {
-      if (isUrlImage(post.post.url)) return <LightboxImg post={post} />;
+    if (post.post.url && isUrlImage(post.post.url)) {
+      return <LightboxImg post={post} />;
+    }
 
-      if (isUrlVideo(post.post.url))
-        return <Video src={post.post.url} css={lightboxCss} controls />;
+    const videoUrl = post.post.embed_video_url || post.post.url;
+    if (videoUrl && isUrlVideo(videoUrl)) {
+      return <Video src={videoUrl} css={lightboxCss} controls />;
     }
 
     if (markdownLoneImage) return <LightboxImg post={post} />;
@@ -188,7 +190,9 @@ export default function PostDetail({
         <>
           {post.post.url &&
             !isUrlImage(post.post.url) &&
-            !isUrlVideo(post.post.url) && <Embed post={post} />}
+            !isUrlVideo(post.post.embed_video_url || post.post.url) && (
+              <Embed post={post} />
+            )}
           <StyledMarkdown>{post.post.body}</StyledMarkdown>
         </>
       );
@@ -197,7 +201,7 @@ export default function PostDetail({
     if (
       post.post.url &&
       !isUrlImage(post.post.url) &&
-      !isUrlVideo(post.post.url)
+      !isUrlVideo(post.post.embed_video_url || post.post.url)
     ) {
       return <StyledEmbed post={post} />;
     }

--- a/src/features/post/inFeed/large/LargePost.tsx
+++ b/src/features/post/inFeed/large/LargePost.tsx
@@ -116,25 +116,28 @@ export default function LargePost({ post, communityMode }: PostProps) {
   );
 
   function renderPostBody() {
-    if (post.post.url) {
-      if (isUrlImage(post.post.url)) {
-        return (
-          <ImageContainer>
-            <Image
-              blur={isNsfwBlurred(post, blurNsfw)}
-              post={post}
-              animationType="zoom"
-            />
-          </ImageContainer>
-        );
-      }
-      if (isUrlVideo(post.post.url)) {
-        return (
-          <ImageContainer>
-            <Video src={post.post.url} blur={isNsfwBlurred(post, blurNsfw)} />
-          </ImageContainer>
-        );
-      }
+    if (post.post.url && isUrlImage(post.post.url)) {
+      return (
+        <ImageContainer>
+          <Image
+            blur={isNsfwBlurred(post, blurNsfw)}
+            post={post}
+            animationType="zoom"
+          />
+        </ImageContainer>
+      );
+    }
+
+    /**
+     * The lemmy api returns an embed_video_url for some urls, try loading those here
+     */
+    const videoUrl = post.post.embed_video_url || post.post.url;
+    if (videoUrl && isUrlVideo(videoUrl)) {
+      return (
+        <ImageContainer>
+          <Video src={videoUrl} blur={isNsfwBlurred(post, blurNsfw)} />
+        </ImageContainer>
+      );
     }
 
     if (markdownLoneImage)


### PR DESCRIPTION
This fix allows posts that have an `embed_video_url` to be able to load on the app instead of needing to visit the url. Since the `embed_video_url` returns a `.mp4` link this allows us to load videos from Imgur and other gif/video services using the existing `Video` component.

Other sites like youtube require an embed instead which I plan to look into in another PR if no one has gotten to that yet.