### PR TITLE
Add my hosted Voyager UI to the Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ NODE_ENV=production PORT=5106 node server.mjs
 - 🇫🇮 [m.lemmy.world](https://m.lemmy.world) - Voyager hosted by the mastodon.world team. [Contact/privacy](https://mastodon.world/about)
 - 🇸🇬 [v.opnxng.com](https://v.opnxng.com) - Voyager hosted by Opnxng in Singapore. [Contact/privacy](https://about.opnxng.com)
 - 🇲🇽 [voyager.nohost.network](https://voyager.nohost.network) - Voyager hosted by Nohost in Mexico. [Contact/privacy](https://nohost.network)
+- 🇺🇸 [vger.thesanewriter.com](https://vger.thesanewriter.com) - Voyager hosted by the lemmy.thesanewriter.com team. [Contact/privacy](https://lemmy.thesanewriter.com/legal)
 
 > **Note**: Community deployments are **NOT** maintained by the Voyager team. They may not be synced with Voyager's source code. Please do your own research about the host servers before using them.
 


### PR DESCRIPTION
I'm hosting a copy of the Voyager UI, and though it's set to use my instance by default it is up to date and can use any of the other instances too. Would it be appropriate to add my Voyager copy to the Ecosystem portion of the README?