### PR TITLE
Chore use latest build stack

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,6 @@ jobs:
           platform: iOS
           build-type: app-store
           certificate: Distribution
-          build-stack: macOS - 2023.03
           destinations: Voyager App Store
           filename: iOS-${{ github.ref_name }}-${{ github.run_id }}
           upload-artifact: iOS-Build.zip


### PR DESCRIPTION
Ionic added WatchOS support to 2023.06