### PR TITLE
feat: Distinguish Post Contexts For Blurring Logic

### DIFF
--- a/src/features/feed/PostCommentFeed.tsx
+++ b/src/features/feed/PostCommentFeed.tsx
@@ -9,6 +9,7 @@ import { receivedComments } from "../comment/commentSlice";
 import Post from "../post/inFeed/Post";
 import CommentHr from "../comment/CommentHr";
 import { FeedContext } from "./FeedContext";
+import { PostContext } from "../../helpers/postContext";
 
 const thickBorderCss = css`
   border-bottom: 8px solid var(--thick-separator-color);
@@ -28,12 +29,14 @@ interface PostCommentFeed
   extends Omit<FeedProps<PostCommentItem>, "renderItemContent"> {
   communityName?: string;
   filterHiddenPosts?: boolean;
+  postContext: PostContext;
 }
 
 export default function PostCommentFeed({
   communityName,
   fetchFn: _fetchFn,
   filterHiddenPosts = true,
+  postContext,
   ...rest
 }: PostCommentFeed) {
   const dispatch = useAppDispatch();
@@ -67,12 +70,17 @@ export default function PostCommentFeed({
     (item: PostCommentItem) => {
       if (isPost(item))
         return (
-          <Post post={item} communityMode={!!communityName} css={borderCss} />
+          <Post
+            post={item}
+            postContext={postContext}
+            communityMode={!!communityName}
+            css={borderCss}
+          />
         );
 
       return <FeedComment comment={item} css={borderCss} />;
     },
-    [communityName, borderCss],
+    [postContext, communityName, borderCss],
   );
 
   const renderItemContent = useCallback(

--- a/src/features/labels/Nsfw.tsx
+++ b/src/features/labels/Nsfw.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
-import { PostView } from "lemmy-js-client";
+import { Community, PostView } from "lemmy-js-client";
 import { getItemActorName } from "../../helpers/lemmy";
 import { OPostBlurNsfw, PostBlurNsfwType } from "../../services/db";
+import { PostContext } from "../../helpers/postContext";
 
 const Container = styled.span`
   font-size: 0.8rem;
@@ -20,19 +21,53 @@ export default function Nsfw() {
 
 const NSFW_INSTANCES = ["lemmynsfw.com"];
 
+/**
+ * Whether a post is NSFW; directly, by it's community, or by its instance
+ */
 export function isNsfw(post: PostView): boolean {
-  if (post.post.nsfw || post.community.nsfw) return true;
+  if (post.post.nsfw) return true;
 
-  if (NSFW_INSTANCES.includes(getItemActorName(post.community))) return true;
+  if (isNsfwCommunity(post.community)) return true;
 
   return false;
 }
 
+/**
+ * Whether a community is marked NSFW
+ */
+export function isNsfwCommunity(community: Community): boolean {
+  if (community.nsfw) return true;
+
+  if (NSFW_INSTANCES.includes(getItemActorName(community))) return true;
+
+  return false;
+}
+
+/**
+ * Whether a feed is marked NSFW
+ */
+export function isNsfwFeed(postContext: PostContext, post: PostView): boolean {
+  if (postContext === "CommunityFeed") return isNsfwCommunity(post.community);
+
+  return false;
+}
+
+/**
+ * Whether a post should be blurred
+ * @param post
+ * @param blurNsfw
+ * @returns
+ */
 export function isNsfwBlurred(
   post: PostView,
+  postContext: PostContext,
   blurNsfw: PostBlurNsfwType,
 ): boolean {
+  if (postContext === "Post") return false;
   if (blurNsfw === OPostBlurNsfw.Never) return false;
+
+  if (blurNsfw === OPostBlurNsfw.SfwFeeds)
+    return isNsfw(post) && !isNsfwFeed(postContext, post);
 
   return isNsfw(post);
 }

--- a/src/features/post/detail/PostDetail.tsx
+++ b/src/features/post/detail/PostDetail.tsx
@@ -188,7 +188,9 @@ export default function PostDetail({
         <>
           {post.post.url &&
             !isUrlImage(post.post.url) &&
-            !isUrlVideo(post.post.url) && <Embed post={post} />}
+            !isUrlVideo(post.post.url) && (
+              <Embed post={post} postContext="Post" />
+            )}
           <StyledMarkdown>{post.post.body}</StyledMarkdown>
         </>
       );
@@ -199,7 +201,7 @@ export default function PostDetail({
       !isUrlImage(post.post.url) &&
       !isUrlVideo(post.post.url)
     ) {
-      return <StyledEmbed post={post} />;
+      return <StyledEmbed post={post} postContext="Post" />;
     }
   }
 

--- a/src/features/post/inFeed/Post.tsx
+++ b/src/features/post/inFeed/Post.tsx
@@ -11,6 +11,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { postHiddenByIdSelector, hidePost, unhidePost } from "../postSlice";
 import AnimateHeight from "react-animate-height";
 import { FeedScrollObserverContext } from "../../feed/FeedScrollObserver";
+import { PostContext } from "../../../helpers/postContext";
 
 const CustomIonItem = styled(IonItem)`
   --padding-start: 0;
@@ -23,6 +24,7 @@ const CustomIonItem = styled(IonItem)`
 
 export interface PostProps {
   post: PostView;
+  postContext: PostContext;
 
   /**
    * Hide the community name, show author name

--- a/src/features/post/inFeed/compact/CompactPost.tsx
+++ b/src/features/post/inFeed/compact/CompactPost.tsx
@@ -97,7 +97,11 @@ const EndDetails = styled.div`
   margin-left: auto;
 `;
 
-export default function CompactPost({ post, communityMode }: PostProps) {
+export default function CompactPost({
+  post,
+  postContext,
+  communityMode,
+}: PostProps) {
   const compactThumbnailPositionType = useAppSelector(
     (state) => state.settings.appearance.compact.thumbnailsPosition,
   );
@@ -113,7 +117,9 @@ export default function CompactPost({ post, communityMode }: PostProps) {
 
   return (
     <Container>
-      {compactThumbnailPositionType === "left" && <Thumbnail post={post} />}
+      {compactThumbnailPositionType === "left" && (
+        <Thumbnail post={post} postContext={postContext} />
+      )}
       <Content>
         <Title isRead={hasBeenRead}>
           <InlineMarkdown>{post.post.name}</InlineMarkdown> {nsfw && <Nsfw />}
@@ -142,7 +148,9 @@ export default function CompactPost({ post, communityMode }: PostProps) {
           </Actions>
         </Aside>
       </Content>
-      {compactThumbnailPositionType === "right" && <Thumbnail post={post} />}
+      {compactThumbnailPositionType === "right" && (
+        <Thumbnail post={post} postContext={postContext} />
+      )}
       {compactShowVotingButtons === true && (
         <EndDetails>
           <VoteButton type="up" postId={post.post.id} />

--- a/src/features/post/inFeed/compact/Thumbnail.tsx
+++ b/src/features/post/inFeed/compact/Thumbnail.tsx
@@ -16,6 +16,7 @@ import {
   CompactThumbnailSizeType,
   OCompactThumbnailSizeType,
 } from "../../../../services/db";
+import { PostContext } from "../../../../helpers/postContext";
 
 function getWidthForSize(size: CompactThumbnailSizeType): number {
   switch (size) {
@@ -109,9 +110,10 @@ const Img = styled.img<{ blur: boolean }>`
 
 interface ImgProps {
   post: PostView;
+  postContext: PostContext;
 }
 
-export default function Thumbnail({ post }: ImgProps) {
+export default function Thumbnail({ post, postContext }: ImgProps) {
   const markdownLoneImage = useMemo(
     () => (post.post.body ? findLoneImage(post.post.body) : undefined),
     [post],
@@ -129,7 +131,10 @@ export default function Thumbnail({ post }: ImgProps) {
     (state) => state.settings.appearance.compact.thumbnailSize,
   );
 
-  const nsfw = useMemo(() => isNsfwBlurred(post, blurNsfw), [post, blurNsfw]);
+  const nsfw = useMemo(
+    () => isNsfwBlurred(post, postContext, blurNsfw),
+    [post, postContext, blurNsfw],
+  );
 
   const isLink = !postImageSrc && post.post.url;
 

--- a/src/features/post/inFeed/large/LargePost.tsx
+++ b/src/features/post/inFeed/large/LargePost.tsx
@@ -103,7 +103,11 @@ const ImageContainer = styled.div`
   margin: 0 -0.75rem;
 `;
 
-export default function LargePost({ post, communityMode }: PostProps) {
+export default function LargePost({
+  post,
+  postContext,
+  communityMode,
+}: PostProps) {
   const hasBeenRead: boolean =
     useAppSelector((state) => state.post.postReadById[post.post.id]) ||
     post.read;
@@ -121,7 +125,7 @@ export default function LargePost({ post, communityMode }: PostProps) {
         return (
           <ImageContainer>
             <Image
-              blur={isNsfwBlurred(post, blurNsfw)}
+              blur={isNsfwBlurred(post, postContext, blurNsfw)}
               post={post}
               animationType="zoom"
             />
@@ -131,7 +135,10 @@ export default function LargePost({ post, communityMode }: PostProps) {
       if (isUrlVideo(post.post.url)) {
         return (
           <ImageContainer>
-            <Video src={post.post.url} blur={isNsfwBlurred(post, blurNsfw)} />
+            <Video
+              src={post.post.url}
+              blur={isNsfwBlurred(post, postContext, blurNsfw)}
+            />
           </ImageContainer>
         );
       }
@@ -141,7 +148,7 @@ export default function LargePost({ post, communityMode }: PostProps) {
       return (
         <ImageContainer>
           <Image
-            blur={isNsfwBlurred(post, blurNsfw)}
+            blur={isNsfwBlurred(post, postContext, blurNsfw)}
             post={post}
             animationType="zoom"
           />
@@ -152,7 +159,7 @@ export default function LargePost({ post, communityMode }: PostProps) {
      * Embedded video, image with a thumbanil
      */
     if (post.post.thumbnail_url && post.post.url) {
-      return <Embed post={post} />;
+      return <Embed post={post} postContext={postContext} />;
     }
 
     /**
@@ -161,7 +168,7 @@ export default function LargePost({ post, communityMode }: PostProps) {
     if (post.post.body) {
       return (
         <>
-          {post.post.url && <Embed post={post} />}
+          {post.post.url && <Embed post={post} postContext={postContext} />}
 
           <PostBody isRead={hasBeenRead}>
             <InlineMarkdown>{post.post.body}</InlineMarkdown>
@@ -171,7 +178,7 @@ export default function LargePost({ post, communityMode }: PostProps) {
     }
 
     if (post.post.url) {
-      return <Embed post={post} />;
+      return <Embed post={post} postContext={postContext} />;
     }
   }
 

--- a/src/features/post/shared/Embed.tsx
+++ b/src/features/post/shared/Embed.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from "../../../store";
 import { isNsfwBlurred } from "../../labels/Nsfw";
 import { setPostRead } from "../postSlice";
 import InAppExternalLink from "../../shared/InAppExternalLink";
+import { PostContext } from "../../../helpers/postContext";
 
 const Container = styled(InAppExternalLink)`
   display: flex;
@@ -70,10 +71,11 @@ const Url = styled.div`
 
 interface EmbedProps {
   post: PostView;
+  postContext: PostContext;
   className?: string;
 }
 
-export default function Embed({ post, className }: EmbedProps) {
+export default function Embed({ post, postContext, className }: EmbedProps) {
   const [error, setError] = useState(false);
   const dispatch = useAppDispatch();
 
@@ -98,7 +100,7 @@ export default function Embed({ post, className }: EmbedProps) {
         <Img
           src={post.post.thumbnail_url}
           draggable="false"
-          blur={isNsfwBlurred(post, blurNsfw)}
+          blur={isNsfwBlurred(post, postContext, blurNsfw)}
           onError={() => setError(true)}
         />
       )}

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -112,7 +112,7 @@ const initialState: SettingsState = {
       profileLabel: OProfileLabelType.Instance,
     },
     posts: {
-      blurNsfw: OPostBlurNsfw.InFeed,
+      blurNsfw: OPostBlurNsfw.Always,
       type: OPostAppearanceType.Large,
     },
     compact: {

--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -110,6 +110,7 @@ export default function Profile({ person }: ProfileProps) {
 
   return (
     <PostCommentFeed
+      postContext="CommunityFeed"
       fetchFn={fetchFn}
       header={header}
       filterHiddenPosts={false}

--- a/src/helpers/postContext.ts
+++ b/src/helpers/postContext.ts
@@ -1,0 +1,1 @@
+export type PostContext = "CommunityFeed" | "SpecialFeed" | "Post";

--- a/src/pages/profile/ProfileFeedHiddenPostsPage.tsx
+++ b/src/pages/profile/ProfileFeedHiddenPostsPage.tsx
@@ -104,6 +104,7 @@ export default function ProfileFeedHiddenPostsPage() {
       </IonHeader>
       <FeedContent>
         <PostCommentFeed
+          postContext="CommunityFeed"
           filterHiddenPosts={false}
           fetchFn={fetchFn}
           limit={LIMIT}

--- a/src/pages/profile/ProfileFeedItemsPage.tsx
+++ b/src/pages/profile/ProfileFeedItemsPage.tsx
@@ -86,7 +86,11 @@ export default function ProfileFeedItemsPage({
         </IonToolbar>
       </IonHeader>
       <FeedContent>
-        <PostCommentFeed fetchFn={fetchFn} filterHiddenPosts={false} />
+        <PostCommentFeed
+          postContext="CommunityFeed"
+          fetchFn={fetchFn}
+          filterHiddenPosts={false}
+        />
       </FeedContent>
     </IonPage>
   );

--- a/src/pages/search/results/SearchFeedResultsPage.tsx
+++ b/src/pages/search/results/SearchFeedResultsPage.tsx
@@ -72,7 +72,7 @@ export default function SearchPostsResults({ type }: SearchPostsResultsProps) {
         </IonToolbar>
       </IonHeader>
       <FeedContent>
-        <PostCommentFeed fetchFn={fetchFn} />
+        <PostCommentFeed postContext="SpecialFeed" fetchFn={fetchFn} />
       </FeedContent>
     </IonPage>
   );

--- a/src/pages/shared/CommunityPage.tsx
+++ b/src/pages/shared/CommunityPage.tsx
@@ -70,7 +70,13 @@ export default function CommunityPage() {
       />
     );
 
-  const feed = <PostCommentFeed fetchFn={fetchFn} communityName={community} />;
+  const feed = (
+    <PostCommentFeed
+      postContext="CommunityFeed"
+      fetchFn={fetchFn}
+      communityName={community}
+    />
+  );
 
   return (
     <FeedContextProvider>

--- a/src/pages/shared/SpecialFeedPage.tsx
+++ b/src/pages/shared/SpecialFeedPage.tsx
@@ -55,7 +55,7 @@ export default function SpecialFeedPage({ type }: SpecialFeedProps) {
     [client, sort, type, jwt],
   );
 
-  const feed = <PostCommentFeed fetchFn={fetchFn} />;
+  const feed = <PostCommentFeed postContext="SpecialFeed" fetchFn={fetchFn} />;
 
   return (
     <TitleSearchProvider>

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -59,7 +59,8 @@ export type CommentThreadCollapse =
   (typeof OCommentThreadCollapse)[keyof typeof OCommentThreadCollapse];
 
 export const OPostBlurNsfw = {
-  InFeed: "in_feed",
+  Always: "always",
+  SfwFeeds: "in_feed",
   Never: "never",
 } as const;
 
@@ -236,7 +237,7 @@ export class WefwefDB extends Dexie {
     });
 
     this.version(3).upgrade(async () => {
-      await this.setSetting("blur_nsfw", OPostBlurNsfw.InFeed);
+      await this.setSetting("blur_nsfw", OPostBlurNsfw.SfwFeeds);
     });
   }
 


### PR DESCRIPTION
I assume I've violated some project conventions with this PR, so please let me know what your thoughts are and if I should be moving anything around.

This changes the blurring logic from a previously Always/Never option to introduce a third option. Now the user can choose to unblur only within NSFW contexts and default to blurring in Home, Popular, All, and any SFW community.

I was a little unsure on some of the labeling, and the type I added (postContext) I wasn't entirely sure where to drop that.