### PR TITLE
fix some images not being available in the file picker

### DIFF
--- a/src/features/post/new/PostEditorRoot.tsx
+++ b/src/features/post/new/PostEditorRoot.tsx
@@ -128,7 +128,7 @@ export default function PostEditorRoot({
 
   const [photoUrl, setPhotoUrl] = useState(initialImage ?? "");
   const [photoPreviewURL, setPhotoPreviewURL] = useState<string | undefined>(
-    initialImage,
+    initialImage
   );
   const [photoUploading, setPhotoUploading] = useState(false);
 
@@ -149,7 +149,7 @@ export default function PostEditorRoot({
         title === initialTitle &&
         url === initialUrl &&
         photoPreviewURL === initialImage &&
-        initialNsfw === (showNsfwToggle && nsfw), // if not showing toggle, it's not nsfw
+        initialNsfw === (showNsfwToggle && nsfw) // if not showing toggle, it's not nsfw
     );
   }, [
     initialPostType,
@@ -193,7 +193,7 @@ export default function PostEditorRoot({
       setText((text) => {
         resolve(text);
         return text;
-      }),
+      })
     );
 
     const postUrl = (() => {
@@ -291,8 +291,8 @@ export default function PostEditorRoot({
         buildGeneralBrowseLink(
           `/c/${getHandle(community)}/comments/${
             postResponse.post_view.post.id
-          }`,
-        ),
+          }`
+        )
       );
   }
 
@@ -395,7 +395,7 @@ export default function PostEditorRoot({
 
                     <HiddenInput
                       type="file"
-                      accept="image/jpeg, image/x-png, image/gif"
+                      accept="image/*"
                       id="photo-upload"
                       onInput={(e) => {
                         const image = (e.target as HTMLInputElement).files?.[0];

--- a/src/features/post/new/PostEditorRoot.tsx
+++ b/src/features/post/new/PostEditorRoot.tsx
@@ -128,7 +128,7 @@ export default function PostEditorRoot({
 
   const [photoUrl, setPhotoUrl] = useState(initialImage ?? "");
   const [photoPreviewURL, setPhotoPreviewURL] = useState<string | undefined>(
-    initialImage
+    initialImage,
   );
   const [photoUploading, setPhotoUploading] = useState(false);
 
@@ -149,7 +149,7 @@ export default function PostEditorRoot({
         title === initialTitle &&
         url === initialUrl &&
         photoPreviewURL === initialImage &&
-        initialNsfw === (showNsfwToggle && nsfw) // if not showing toggle, it's not nsfw
+        initialNsfw === (showNsfwToggle && nsfw), // if not showing toggle, it's not nsfw
     );
   }, [
     initialPostType,
@@ -193,7 +193,7 @@ export default function PostEditorRoot({
       setText((text) => {
         resolve(text);
         return text;
-      })
+      }),
     );
 
     const postUrl = (() => {
@@ -291,8 +291,8 @@ export default function PostEditorRoot({
         buildGeneralBrowseLink(
           `/c/${getHandle(community)}/comments/${
             postResponse.post_view.post.id
-          }`
-        )
+          }`,
+        ),
       );
   }
 

--- a/src/features/shared/markdown/editing/MarkdownToolbar.tsx
+++ b/src/features/shared/markdown/editing/MarkdownToolbar.tsx
@@ -185,7 +185,7 @@ export default function MarkdownToolbar({
     if (!textareaRef.current) return;
 
     setText((text) =>
-      insert(text, selectionLocation.current, `\n![](${imageUrl})\n`)
+      insert(text, selectionLocation.current, `\n![](${imageUrl})\n`),
     );
   }
 
@@ -210,7 +210,7 @@ export default function MarkdownToolbar({
           selectionLocation.current + event.detail.data.length;
 
         setText((text) =>
-          insert(text, selectionLocation.current, event.detail.data)
+          insert(text, selectionLocation.current, event.detail.data),
         );
 
         if (textareaRef.current) {

--- a/src/features/shared/markdown/editing/MarkdownToolbar.tsx
+++ b/src/features/shared/markdown/editing/MarkdownToolbar.tsx
@@ -185,7 +185,7 @@ export default function MarkdownToolbar({
     if (!textareaRef.current) return;
 
     setText((text) =>
-      insert(text, selectionLocation.current, `\n![](${imageUrl})\n`),
+      insert(text, selectionLocation.current, `\n![](${imageUrl})\n`)
     );
   }
 
@@ -210,7 +210,7 @@ export default function MarkdownToolbar({
           selectionLocation.current + event.detail.data.length;
 
         setText((text) =>
-          insert(text, selectionLocation.current, event.detail.data),
+          insert(text, selectionLocation.current, event.detail.data)
         );
 
         if (textareaRef.current) {
@@ -243,7 +243,7 @@ export default function MarkdownToolbar({
                   display: none;
                 `}
                 type="file"
-                accept="image/jpeg, image/x-png, image/gif"
+                accept="image/*"
                 id="photo-upload"
                 onInput={(e) => {
                   const image = (e.target as HTMLInputElement).files?.[0];


### PR DESCRIPTION
Wasn't able to select some images to use in posts/comments. This change fixes that

![Screenshot_20230821_130130_Files_2](https://github.com/aeharding/voyager/assets/715417/3e4c9c37-209a-4620-8841-185c5fa55569)


Note: looks like lemmy file input uses both `images/*, video/*`, but since uploads are routed through the voyager instance, I am not sure how it would impact it. so I have omitted video/* from this patch

![Screenshot_20230821_131953](https://github.com/aeharding/voyager/assets/715417/b87d216c-5c4d-420b-a2c1-fa5b2e79d371)
