### PR TITLE
translucent tab bar in ios

### DIFF
--- a/src/TabbedRoutes.tsx
+++ b/src/TabbedRoutes.tsx
@@ -431,7 +431,7 @@ export default function TabbedRoutes() {
         {/* But this isn't trivial with needing to rewrite URLs... */}
         <IonTabs key={iss ?? getDefaultServer()}>
           {routes}
-          <IonTabBar slot="bottom">
+          <IonTabBar slot="bottom" translucent>
             <IonTabButton
               disabled={isPostsButtonDisabled}
               tab="posts"

--- a/src/features/auth/AccountSwitcher.tsx
+++ b/src/features/auth/AccountSwitcher.tsx
@@ -48,7 +48,7 @@ export default function AccountSwitcher({
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             {editing ? (

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -219,7 +219,7 @@ export default function Login({
     >
       <input type="submit" /> {/* Hack */}
       <IonPage ref={pageRef}>
-        <IonHeader>
+        <IonHeader translucent>
           <IonToolbar>
             <IonButtons slot="start">
               <IonButton

--- a/src/features/comment/compose/edit/CommentEdit.tsx
+++ b/src/features/comment/compose/edit/CommentEdit.tsx
@@ -68,7 +68,7 @@ export default function CommentEdit({
 
   return (
     <>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonButton color="medium" onClick={() => dismiss()}>

--- a/src/features/comment/compose/reply/CommentReply.tsx
+++ b/src/features/comment/compose/reply/CommentReply.tsx
@@ -120,7 +120,7 @@ export default function CommentReply({
 
   return (
     <>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonButton color="medium" onClick={() => dismiss()}>

--- a/src/features/post/new/NewPostText.tsx
+++ b/src/features/post/new/NewPostText.tsx
@@ -89,7 +89,7 @@ export default function NewPostText({
 
   return (
     <>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton disabled={loading} />

--- a/src/features/post/new/PostEditorRoot.tsx
+++ b/src/features/post/new/PostEditorRoot.tsx
@@ -330,7 +330,7 @@ export default function PostEditorRoot({
 
   return (
     <>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonButton color="medium" onClick={() => dismiss()}>

--- a/src/features/settings/terms/TermsSheet.tsx
+++ b/src/features/settings/terms/TermsSheet.tsx
@@ -16,7 +16,7 @@ interface TermsSheetProps {
 export default function TermsSheet({ onDismiss }: TermsSheetProps) {
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonButton color="medium" onClick={() => onDismiss()}>

--- a/src/features/shared/markdown/editing/PreviewModal.tsx
+++ b/src/features/shared/markdown/editing/PreviewModal.tsx
@@ -32,7 +32,7 @@ export default function PreviewModal({
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="end">
             <IonButton color="primary" strong onClick={() => onDismiss()}>

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,19 @@
 .ios .tab-bar-translucent {
   --background: inherit;
   --background-focused: inherit;
+  background: inherit;
+}
+
+/* .ios .header-translucent {
+  --background: inherit;
+  --background-focused: inherit;
   background: --tabbar-background;
+} */
+
+.ios .toolbar-title-default {
+  --background: inherit;
+  --background-focused: inherit;
+  background: inherit;
 }
 
 html {

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,12 @@
   --sal: env(safe-area-inset-left);
 }
 
+.ios .tab-bar-translucent {
+  --background: inherit;
+  --background-focused: inherit;
+  background: --tabbar-background;
+}
+
 html {
   -webkit-text-size-adjust: 100%; /* Prevent font scaling in landscape while allowing user zoom */
 }

--- a/src/pages/inbox/BoxesPage.tsx
+++ b/src/pages/inbox/BoxesPage.tsx
@@ -37,13 +37,13 @@ export default function BoxesPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>Boxes</IonTitle>
         </IonToolbar>
       </IonHeader>
       <AppContent scrollY>
-        <IonHeader collapse="condense">
+        <IonHeader translucent collapse="condense">
           <IonToolbar>
             <IonTitle size="large">Boxes</IonTitle>
           </IonToolbar>

--- a/src/pages/inbox/ConversationPage.tsx
+++ b/src/pages/inbox/ConversationPage.tsx
@@ -218,7 +218,7 @@ export default function ConversationPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton

--- a/src/pages/inbox/InboxPage.tsx
+++ b/src/pages/inbox/InboxPage.tsx
@@ -78,7 +78,7 @@ export default function InboxPage({ showRead }: InboxPageProps) {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/inbox" text="Boxes" />

--- a/src/pages/inbox/MentionsPage.tsx
+++ b/src/pages/inbox/MentionsPage.tsx
@@ -44,7 +44,7 @@ export default function MentionsPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/inbox" text="Boxes" />

--- a/src/pages/inbox/MessagesPage.tsx
+++ b/src/pages/inbox/MessagesPage.tsx
@@ -63,7 +63,7 @@ export default function MessagesPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/inbox" text="Boxes" />

--- a/src/pages/inbox/RepliesPage.tsx
+++ b/src/pages/inbox/RepliesPage.tsx
@@ -53,7 +53,7 @@ export default function RepliesPage({ type }: RepliesPageProps) {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/inbox" text="Boxes" />

--- a/src/pages/posts/CommunitiesPage.tsx
+++ b/src/pages/posts/CommunitiesPage.tsx
@@ -18,7 +18,7 @@ export default function CommunitiesPage() {
 
   return (
     <IonPage ref={pageRef}>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>Communities</IonTitle>
           <IonButtons slot="end">

--- a/src/pages/posts/PostPage.tsx
+++ b/src/pages/posts/PostPage.tsx
@@ -102,7 +102,7 @@ export default function PostPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <AppBackButton

--- a/src/pages/profile/ProfileFeedHiddenPostsPage.tsx
+++ b/src/pages/profile/ProfileFeedHiddenPostsPage.tsx
@@ -91,7 +91,7 @@ export default function ProfileFeedHiddenPostsPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>Hidden Posts</IonTitle>
           <IonButtons slot="start">

--- a/src/pages/profile/ProfileFeedItemsPage.tsx
+++ b/src/pages/profile/ProfileFeedItemsPage.tsx
@@ -74,7 +74,7 @@ export default function ProfileFeedItemsPage({
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>{type}</IonTitle>
           <IonButtons slot="start">

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -32,7 +32,7 @@ export default function ProfilePage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           {handle ? (
             <>

--- a/src/pages/profile/UserPage.tsx
+++ b/src/pages/profile/UserPage.tsx
@@ -24,7 +24,7 @@ export default function UserPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton />

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -25,7 +25,7 @@ export default function SearchPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <form
             onSubmit={async (e) => {

--- a/src/pages/search/results/SearchCommunitiesPage.tsx
+++ b/src/pages/search/results/SearchCommunitiesPage.tsx
@@ -52,7 +52,7 @@ export default function SearchCommunitiesPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton

--- a/src/pages/search/results/SearchFeedResultsPage.tsx
+++ b/src/pages/search/results/SearchFeedResultsPage.tsx
@@ -55,7 +55,7 @@ export default function SearchPostsResults({ type }: SearchPostsResultsProps) {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton

--- a/src/pages/settings/AppIconPage.tsx
+++ b/src/pages/settings/AppIconPage.tsx
@@ -12,7 +12,7 @@ import AppIcon from "../../features/settings/app-icon/AppIcon";
 export default function AppIconPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/AppearancePage.tsx
+++ b/src/pages/settings/AppearancePage.tsx
@@ -12,7 +12,7 @@ import AppearanceSettings from "../../features/settings/appearance/AppearanceSet
 export default function AppearancePage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/AppearanceThemePage.tsx
+++ b/src/pages/settings/AppearanceThemePage.tsx
@@ -12,7 +12,7 @@ import Theme from "../../features/settings/appearance/themes/Theme";
 export default function AppearanceThemePage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/BlocksSettingsPage.tsx
+++ b/src/pages/settings/BlocksSettingsPage.tsx
@@ -29,7 +29,7 @@ export default function BlocksSettingsPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/DeviceModeSettingsPage.tsx
+++ b/src/pages/settings/DeviceModeSettingsPage.tsx
@@ -12,7 +12,7 @@ import SelectDeviceMode from "../../features/settings/appearance/themes/system/S
 export default function DeviceModeSettingsPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton

--- a/src/pages/settings/GeneralPage.tsx
+++ b/src/pages/settings/GeneralPage.tsx
@@ -12,7 +12,7 @@ import GeneralSettings from "../../features/settings/general/GeneralSettings";
 export default function GeneralPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/GesturesPage.tsx
+++ b/src/pages/settings/GesturesPage.tsx
@@ -12,7 +12,7 @@ import SwipeSettings from "../../features/settings/gestures/SwipeSettings";
 export default function GesturesPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/HidingSettingsPage.tsx
+++ b/src/pages/settings/HidingSettingsPage.tsx
@@ -12,7 +12,7 @@ import HidingSettings from "../../features/settings/general/hiding/HidingSetting
 export default function HidingSettingsPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings/general" text="General" />

--- a/src/pages/settings/InstallAppPage.tsx
+++ b/src/pages/settings/InstallAppPage.tsx
@@ -168,7 +168,7 @@ export default function InstallAppPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/RedditDataMigratePage.tsx
+++ b/src/pages/settings/RedditDataMigratePage.tsx
@@ -101,7 +101,7 @@ export default function RedditMigratePage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -69,13 +69,13 @@ export default function SettingsPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>Settings</IonTitle>
         </IonToolbar>
       </IonHeader>
       <AppContent scrollY>
-        <IonHeader collapse="condense">
+        <IonHeader translucent collapse="condense">
           <IonToolbar>
             <IonTitle size="large">Settings</IonTitle>
           </IonToolbar>

--- a/src/pages/settings/TermsPage.tsx
+++ b/src/pages/settings/TermsPage.tsx
@@ -12,7 +12,7 @@ import Terms from "../../features/settings/terms/Terms";
 export default function TermsPage() {
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/settings/UpdateAppPage.tsx
+++ b/src/pages/settings/UpdateAppPage.tsx
@@ -62,7 +62,7 @@ export default function UpdateAppPage() {
 
   return (
     <IonPage className="grey-bg">
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <IonBackButton defaultHref="/settings" text="Settings" />

--- a/src/pages/shared/CommunityPage.tsx
+++ b/src/pages/shared/CommunityPage.tsx
@@ -76,7 +76,7 @@ export default function CommunityPage() {
     <FeedContextProvider>
       <TitleSearchProvider>
         <IonPage>
-          <IonHeader>
+          <IonHeader translucent>
             <IonToolbar>
               <IonButtons slot="start">
                 <AppBackButton

--- a/src/pages/shared/CommunitySidebarPage.tsx
+++ b/src/pages/shared/CommunitySidebarPage.tsx
@@ -36,7 +36,7 @@ export default function CommunitySidebarPage() {
 
   return (
     <IonPage>
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
             <AppBackButton

--- a/src/pages/shared/InstanceSidebarPage.tsx
+++ b/src/pages/shared/InstanceSidebarPage.tsx
@@ -28,7 +28,7 @@ export default function InstanceSidebarPage() {
     <FeedContextProvider>
       <TitleSearchProvider>
         <IonPage>
-          <IonHeader>
+          <IonHeader translucent>
             <IonToolbar>
               <IonButtons slot="start">
                 <AppBackButton

--- a/src/pages/shared/SelectTextModal.tsx
+++ b/src/pages/shared/SelectTextModal.tsx
@@ -87,7 +87,7 @@ export default function SelectTextModal({
       breakpoints={[0, 0.5, 1]}
       autoFocus
     >
-      <IonHeader>
+      <IonHeader translucent>
         <IonToolbar>
           <IonTitle>
             <Centered>Select Text</Centered>

--- a/src/pages/shared/SpecialFeedPage.tsx
+++ b/src/pages/shared/SpecialFeedPage.tsx
@@ -61,7 +61,7 @@ export default function SpecialFeedPage({ type }: SpecialFeedProps) {
     <TitleSearchProvider>
       <FeedContextProvider>
         <IonPage>
-          <IonHeader>
+          <IonHeader translucent>
             <IonToolbar>
               <IonButtons slot="start">
                 <IonBackButton


### PR DESCRIPTION
- add translucent property to `<IonTabBar>`
- fix the style in `index.css`

### Dark Mode (with pure dark disabled)
<img width="361" alt="image" src="https://github.com/aeharding/voyager/assets/10240002/43535c9b-68fb-481d-b1a5-22b1189edcd0">

### Light Mode
<img width="359" alt="image" src="https://github.com/aeharding/voyager/assets/10240002/671480b2-8326-4a6a-b902-f81eaf40eed8">

### Pure Dark Mode
<img width="348" alt="image" src="https://github.com/aeharding/voyager/assets/10240002/1477e5d7-0dc7-49ff-b6e6-fc130af8f7dd">
