### PR TITLE
Fix bug where tab routes can become invalid

### DIFF
--- a/src/helpers/routes.ts
+++ b/src/helpers/routes.ts
@@ -1,5 +1,5 @@
 import { useAppSelector } from "../store";
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useRef } from "react";
 import { TabContext } from "../TabContext";
 
 export function useBuildGeneralBrowseLink() {
@@ -8,8 +8,12 @@ export function useBuildGeneralBrowseLink() {
     (state) => state.auth.connectedInstance,
   );
 
+  // If connectedServer changes while we're off-tab, we don't want to
+  // change the tab value - just rerender the connectedServer value
+  const renderedTabRef = useRef(tab);
+
   const buildGeneralBrowseLink = useCallback(
-    (path: string) => `/${tab}/${connectedServer}${path}`,
+    (path: string) => `/${renderedTabRef.current}/${connectedServer}${path}`,
     // tab should never dynamically change for a rendered buildGeneralBrowseLink tab. So don't re-render
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [connectedServer],


### PR DESCRIPTION
1. Logout
2. Go to posts tab
3. Go to profile tab
4. Login
5. Immediately switch to posts tab
6. Observe tapping home feed blanks page