### PR TITLE
Improve performance of comment collapse

### DIFF
--- a/src/features/comment/CommentTree.tsx
+++ b/src/features/comment/CommentTree.tsx
@@ -26,14 +26,13 @@ export default function CommentTree({
   rootIndex,
 }: CommentTreeProps) {
   const dispatch = useAppDispatch();
-  const commentCollapsedById = useAppSelector(
-    (state) => state.comment.commentCollapsedById,
+  const collapsed = useAppSelector(
+    (state) =>
+      state.comment.commentCollapsedById[comment.comment_view.comment.id],
   );
   const { tapToCollapse } = useAppSelector(
     (state) => state.settings.general.comments,
   );
-
-  const collapsed = commentCollapsedById[comment.comment_view.comment.id];
 
   // Comment context chains don't show missing for parents
   const showMissing = useMemo(() => {


### PR DESCRIPTION
Previously, all comments were forced to run a render cycle due to this useSelector(). With this fix, the useSelector() will only trigger a render of the comment that was collapsed.

This appears to have a noticeable performance improvement, especially on low-end devices.