### PR TITLE
Fix moderators list empty in sidebar edge case

### DIFF
--- a/src/features/community/CommunitySummary.tsx
+++ b/src/features/community/CommunitySummary.tsx
@@ -62,6 +62,7 @@ interface CommunitySummaryProps {
 export default function CommunitySummary({ community }: CommunitySummaryProps) {
   const { isSubscribed, subscribe, view } = useCommunityActions(
     community.community,
+    community.subscribed,
   );
 
   return (

--- a/src/features/community/communitySlice.ts
+++ b/src/features/community/communitySlice.ts
@@ -32,12 +32,6 @@ export const communitySlice = createSlice({
       state.communityByHandle[getHandle(action.payload.community)] =
         action.payload;
     },
-    receivedCommunities: (state, action: PayloadAction<CommunityView[]>) => {
-      for (const communityView of action.payload) {
-        state.communityByHandle[getHandle(communityView.community)] =
-          communityView;
-      }
-    },
     recievedTrendingCommunities: (
       state,
       action: PayloadAction<CommunityView[]>,
@@ -63,7 +57,6 @@ export const communitySlice = createSlice({
 // Action creators are generated for each case reducer function
 export const {
   receivedCommunity,
-  receivedCommunities,
   recievedTrendingCommunities,
   resetCommunities,
   setFavorites,

--- a/src/pages/search/results/SearchCommunitiesPage.tsx
+++ b/src/pages/search/results/SearchCommunitiesPage.tsx
@@ -14,11 +14,10 @@ import useClient from "../../../helpers/useClient";
 import { LIMIT } from "../../../services/lemmy";
 import { useParams } from "react-router";
 import PostSort from "../../../features/feed/PostSort";
-import { useAppDispatch, useAppSelector } from "../../../store";
+import { useAppSelector } from "../../../store";
 import { CommunityView, LemmyHttp } from "lemmy-js-client";
 import CommunityFeed from "../../../features/feed/CommunityFeed";
 import { notEmpty } from "../../../helpers/array";
-import { receivedCommunities } from "../../../features/community/communitySlice";
 import { isLemmyError } from "../../../helpers/lemmy";
 
 export default function SearchCommunitiesPage() {
@@ -26,7 +25,6 @@ export default function SearchCommunitiesPage() {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
   const client = useClient();
   const sort = useAppSelector((state) => state.post.sort);
-  const dispatch = useAppDispatch();
 
   const search = decodeURIComponent(_encodedSearch);
 
@@ -45,11 +43,9 @@ export default function SearchCommunitiesPage() {
         sort,
       });
 
-      dispatch(receivedCommunities(response.communities));
-
       return response.communities;
     },
-    [client, search, sort, dispatch],
+    [client, search, sort],
   );
 
   return (

--- a/src/pages/shared/CommunitySidebarPage.tsx
+++ b/src/pages/shared/CommunitySidebarPage.tsx
@@ -24,19 +24,20 @@ export default function CommunitySidebarPage() {
     community: string;
   }>();
 
-  const communityByHandle = useAppSelector(
-    (state) => state.community.communityByHandle,
+  const communityView = useAppSelector(
+    (state) => state.community.communityByHandle[community],
   );
-
-  const communityView = communityByHandle[community];
+  const mods = useAppSelector(
+    (state) => state.community.modsByHandle[community],
+  );
 
   useSetActivePage(pageRef);
 
   useEffect(() => {
-    if (communityView) return;
+    if (communityView && mods) return;
 
     dispatch(getCommunity(community));
-  }, [community, dispatch, communityView]);
+  }, [community, dispatch, communityView, mods]);
 
   return (
     <IonPage ref={pageRef}>


### PR DESCRIPTION
Resolves #967

Repro:

 1. Search community name, don't click on community
 2. Go to home/all/local feed, find community
 3. Use long press to bring up sidebar. Observe mod list empty