### PR TITLE
Enable inline images in comments by default

### DIFF
--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -164,7 +164,7 @@ const initialState: SettingsState = {
       jumpButtonPosition: OJumpButtonPositionType.RightBottom,
       highlightNewAccount: true,
       touchFriendlyLinks: true,
-      showCommentImages: false,
+      showCommentImages: true,
     },
     posts: {
       disableMarkingRead: false,


### PR DESCRIPTION
Given the large number of images posted on Lemmy in comments, for better or worse, this should probably be enabled by default.