### PR TITLE
Fix mod approve/remove/restore post/comment lifecycle

### DIFF
--- a/src/features/moderation/useCommentModActions.tsx
+++ b/src/features/moderation/useCommentModActions.tsx
@@ -23,7 +23,7 @@ import {
   modRemoveComment,
 } from "../comment/commentSlice";
 import { stringifyReports } from "./usePostModActions";
-import { reportsByCommentIdSelector } from "./modSlice";
+import { reportsByCommentIdSelector, resolveCommentReport } from "./modSlice";
 
 export default function useCommentModActions(commentView: CommentView) {
   const [presentAlert] = useIonAlert();
@@ -65,28 +65,42 @@ export default function useCommentModActions(commentView: CommentView) {
               },
             }
           : undefined,
-        {
-          text: "Approve",
-          icon: checkmarkCircleOutline,
-          handler: () => {
-            (async () => {
-              await dispatch(modRemoveComment(comment.id, false));
+        !comment.removed && reports?.length
+          ? {
+              text: "Approve",
+              icon: checkmarkCircleOutline,
+              handler: () => {
+                (async () => {
+                  await dispatch(resolveCommentReport(comment.id));
 
-              presentToast(commentApproved);
-            })();
-          },
-        },
-        {
-          text: "Remove",
-          icon: trashOutline,
-          handler: () => {
-            (async () => {
-              await dispatch(modRemoveComment(comment.id, true));
+                  presentToast(commentApproved);
+                })();
+              },
+            }
+          : undefined,
+        !comment.removed
+          ? {
+              text: "Remove",
+              icon: trashOutline,
+              handler: () => {
+                (async () => {
+                  await dispatch(modRemoveComment(comment.id, true));
 
-              presentToast(commentRemoved);
-            })();
-          },
-        },
+                  presentToast(commentRemoved);
+                })();
+              },
+            }
+          : {
+              text: "Restore",
+              icon: checkmarkCircleOutline,
+              handler: () => {
+                (async () => {
+                  await dispatch(modRemoveComment(comment.id, false));
+
+                  presentToast(commentApproved);
+                })();
+              },
+            },
         {
           text: "Comment Nuke",
           icon: colorWandOutline,

--- a/src/helpers/toastMessages.ts
+++ b/src/helpers/toastMessages.ts
@@ -113,6 +113,13 @@ export const postApproved: AppToastOptions = {
   icon: checkmark,
 };
 
+export const postRestored: AppToastOptions = {
+  message: "Post restored",
+  color: "success",
+  centerText: true,
+  icon: checkmark,
+};
+
 export const commentRemoved: AppToastOptions = {
   message: "Comment removed",
   color: "success",
@@ -122,6 +129,13 @@ export const commentRemoved: AppToastOptions = {
 
 export const commentApproved: AppToastOptions = {
   message: "Comment approved",
+  color: "success",
+  centerText: true,
+  icon: checkmark,
+};
+
+export const commentRestored: AppToastOptions = {
+  message: "Comment restored",
   color: "success",
   centerText: true,
   icon: checkmark,


### PR DESCRIPTION
 1. A post/comment with a report will only have reports resolved when approved.
 2. Introduced concept of restoring post/comment
 3. Mod actions list will only have relevant actions, so you cannot double approve

Resolves #983