### PR TITLE
feat: Manage instances list

### DIFF
--- a/src/TabbedRoutes.tsx
+++ b/src/TabbedRoutes.tsx
@@ -27,6 +27,7 @@ import InboxAuthRequired from "./pages/inbox/InboxAuthRequired";
 import UpdateAppPage from "./pages/settings/UpdateAppPage";
 import AppearancePage from "./pages/settings/AppearancePage";
 import CommunitySidebarPage from "./pages/shared/CommunitySidebarPage";
+import ManageInstancesPage from "./pages/settings/ManageInstancesPage";
 import RedditMigratePage from "./pages/settings/RedditDataMigratePage";
 import ProfilePage from "./pages/profile/ProfilePage";
 import ProfileFeedHiddenPostsPage from "./pages/profile/ProfileFeedHiddenPostsPage";
@@ -354,6 +355,9 @@ export default function TabbedRoutes() {
             </Route>
             <Route exact path="/settings/blocks">
               <BlocksSettingsPage />
+            </Route>
+            <Route exact path="/settings/manage-instances">
+              <ManageInstancesPage />
             </Route>
             <Route exact path="/settings/reddit-migrate">
               <RedditMigratePage />

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -24,7 +24,7 @@ import { getClient } from "../../services/lemmy";
 import { IonInputCustomEvent } from "@ionic/core";
 import TermsSheet from "../settings/terms/TermsSheet";
 import { preventPhotoswipeGalleryFocusTrap } from "../gallery/GalleryImg";
-import { getCustomServers } from "../../services/app";
+import { useCustomServers } from "../../services/app";
 import { isNative } from "../../helpers/device";
 import { Browser } from "@capacitor/browser";
 import useAppToast from "../../helpers/useAppToast";
@@ -60,7 +60,7 @@ export default function Login({
 }) {
   const presentToast = useAppToast();
   const dispatch = useAppDispatch();
-  const [servers] = useState(getCustomServers());
+  const [servers] = useCustomServers();
   const [server, setServer] = useState(servers[0]);
   const [customServer, setCustomServer] = useState("");
   const [serverConfirmed, setServerConfirmed] = useState(false);
@@ -258,7 +258,7 @@ export default function Login({
                 onIonChange={(e) => setServer(e.target.value)}
               >
                 <IonList inset>
-                  {servers.slice(0, 3).map((server) => (
+                  {servers.map((server) => (
                     <IonItem disabled={loading} key={server}>
                       <IonRadio value={server} key={server}>
                         {server}

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -33,6 +33,7 @@ import {
   OldLemmyErrorValue,
   isLemmyError,
 } from "../../helpers/lemmy";
+import { uniq } from "lodash";
 
 const JOIN_LEMMY_URL = "https://join-lemmy.org/instances";
 
@@ -60,7 +61,7 @@ export default function Login({
 }) {
   const presentToast = useAppToast();
   const dispatch = useAppDispatch();
-  const [servers] = useCustomServers();
+  const [servers, setServers] = useCustomServers();
   const [server, setServer] = useState(servers[0]);
   const [customServer, setCustomServer] = useState("");
   const [serverConfirmed, setServerConfirmed] = useState(false);
@@ -202,6 +203,7 @@ export default function Login({
       message: "Login successful",
       color: "success",
     });
+    setServers(uniq([...servers, customServer]));
   }
 
   return (

--- a/src/features/settings/manage-instances/Instance.tsx
+++ b/src/features/settings/manage-instances/Instance.tsx
@@ -1,0 +1,61 @@
+import {
+  IonButton,
+  IonIcon,
+  IonItemOption,
+  IonItemOptions,
+  IonItemSliding,
+  IonLabel,
+  ItemSlidingCustomEvent,
+} from "@ionic/react";
+import { removeCircle } from "ionicons/icons";
+import { useRef } from "react";
+import styled from "@emotion/styled";
+import { InsetIonItem } from "../shared/formatting";
+
+const RemoveIcon = styled(IonIcon)`
+  position: relative;
+
+  &:after {
+    z-index: -1;
+    content: "";
+    position: absolute;
+    inset: 5px;
+    border-radius: 50%;
+    background: white;
+  }
+`;
+
+interface InstanceProps {
+  editing: boolean;
+  domain: string;
+  onRemove: (instance: string) => void;
+}
+
+export default function Instance({ editing, domain, onRemove }: InstanceProps) {
+  const slidingRef = useRef<ItemSlidingCustomEvent["target"]>(null);
+  const removeInstance = () => onRemove(domain);
+
+  return (
+    <IonItemSliding ref={slidingRef}>
+      <IonItemOptions side="end" onIonSwipe={removeInstance}>
+        <IonItemOption color="danger" expandable onClick={removeInstance}>
+          Remove
+        </IonItemOption>
+      </IonItemOptions>
+      <InsetIonItem>
+        {editing && (
+          <IonButton
+            color="none"
+            slot="start"
+            onClick={() => {
+              slidingRef.current?.open("end");
+            }}
+          >
+            <RemoveIcon icon={removeCircle} color="danger" slot="icon-only" />
+          </IonButton>
+        )}
+        <IonLabel>{domain}</IonLabel>
+      </InsetIonItem>
+    </IonItemSliding>
+  );
+}

--- a/src/features/settings/manage-instances/ManageInstances.tsx
+++ b/src/features/settings/manage-instances/ManageInstances.tsx
@@ -1,0 +1,118 @@
+import { IonLabel, IonList, useIonAlert } from "@ionic/react";
+import { InsetIonItem, ListHeader } from "../shared/formatting";
+import { getCustomServers } from "../../../services/app";
+import { getClient } from "../../../services/lemmy";
+import useAppToast from "../../../helpers/useAppToast";
+import { uniq, without } from "lodash";
+import { useState } from "react";
+import Instance from "./Instance";
+
+interface ManageInstancesProps {
+  editing: boolean;
+}
+
+export default function ManageInstances({ editing }: ManageInstancesProps) {
+  const [instances, setInstances] = useState(getCustomServers());
+  const [presentAlert] = useIonAlert();
+  const presentToast = useAppToast();
+
+  const validHostname = (customServer: string) => {
+    try {
+      return new URL(
+        customServer.startsWith("https://")
+          ? customServer
+          : `https://${customServer}`,
+      ).hostname;
+    } catch (e) {
+      return undefined;
+    }
+  };
+
+  async function confirmInstance(instance: string) {
+    if (instance) {
+      const hostname = validHostname(instance);
+      if (!hostname) {
+        presentToast({
+          message: `${instance} is not a valid server name. Please try again`,
+          color: "danger",
+          fullscreen: true,
+        });
+
+        return;
+      }
+
+      try {
+        await getClient(hostname).getSite();
+      } catch (error) {
+        presentToast({
+          message: `Problem connecting. Either ${hostname} is not a Lemmy server or it is down. Please try again`,
+          color: "danger",
+          fullscreen: true,
+        });
+
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function addInstance() {
+    presentAlert({
+      header: "Add custom instance",
+      buttons: [
+        {
+          text: "OK",
+          handler: async ({ instance }) => {
+            if (!instance.trim()) return;
+
+            if (await confirmInstance(instance)) {
+              setInstances(uniq([...instances, instance.trim()]));
+            }
+          },
+        },
+        "Cancel",
+      ],
+      inputs: [
+        {
+          name: "instance",
+          placeholder: "lemmy.world",
+        },
+      ],
+    });
+  }
+
+  function removeInstance(domain: string) {
+    setInstances(without(instances, domain));
+  }
+
+  function resetInstances() {
+    setInstances(getCustomServers());
+  }
+
+  return (
+    <>
+      <ListHeader>
+        <IonLabel>Instances</IonLabel>
+      </ListHeader>
+      <IonList inset>
+        {instances.map((instance) => (
+          <Instance
+            key={instance}
+            domain={instance}
+            editing={editing}
+            onRemove={removeInstance}
+          />
+        ))}
+        <InsetIonItem onClick={addInstance}>
+          <IonLabel color="primary">Add Instance</IonLabel>
+        </InsetIonItem>
+      </IonList>
+      <IonList inset>
+        <InsetIonItem onClick={resetInstances}>
+          <IonLabel color="danger">Reset Instance List</IonLabel>
+        </InsetIonItem>
+      </IonList>
+    </>
+  );
+}

--- a/src/features/settings/manage-instances/ManageInstances.tsx
+++ b/src/features/settings/manage-instances/ManageInstances.tsx
@@ -1,10 +1,9 @@
 import { IonLabel, IonList, useIonAlert } from "@ionic/react";
 import { InsetIonItem, ListHeader } from "../shared/formatting";
-import { getCustomServers } from "../../../services/app";
+import { useCustomServers } from "../../../services/app";
 import { getClient } from "../../../services/lemmy";
 import useAppToast from "../../../helpers/useAppToast";
 import { uniq, without } from "lodash";
-import { useState } from "react";
 import Instance from "./Instance";
 
 interface ManageInstancesProps {
@@ -12,7 +11,7 @@ interface ManageInstancesProps {
 }
 
 export default function ManageInstances({ editing }: ManageInstancesProps) {
-  const [instances, setInstances] = useState(getCustomServers());
+  const [instances, setInstances, resetInstances] = useCustomServers();
   const [presentAlert] = useIonAlert();
   const presentToast = useAppToast();
 
@@ -82,12 +81,8 @@ export default function ManageInstances({ editing }: ManageInstancesProps) {
     });
   }
 
-  function removeInstance(domain: string) {
-    setInstances(without(instances, domain));
-  }
-
-  function resetInstances() {
-    setInstances(getCustomServers());
+  function removeInstance(instance: string) {
+    setInstances(without(instances, instance));
   }
 
   return (

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -37,6 +37,7 @@ import {
   TapToCollapseType,
   OTapToCollapseType,
 } from "../../services/db";
+import { DEFAULT_LEMMY_SERVERS } from "../../services/app";
 import { get, set } from "./storage";
 import { Mode } from "@ionic/core";
 
@@ -108,6 +109,7 @@ interface SettingsState {
   blocks: {
     keywords: string[];
   };
+  instances: string[];
 }
 
 const LOCALSTORAGE_KEYS = {
@@ -183,6 +185,7 @@ const initialState: SettingsState = {
   blocks: {
     keywords: [],
   },
+  instances: DEFAULT_LEMMY_SERVERS,
 };
 
 // We continue using localstorage for specific items because indexeddb is slow
@@ -389,6 +392,11 @@ export const appearanceSlice = createSlice({
 
       db.setSetting("link_handler", action.payload);
     },
+    setInstances(state, action: PayloadAction<string[]>) {
+      state.instances = action.payload;
+
+      db.setSetting("instances", action.payload);
+    },
 
     resetSettings: () => ({
       ...initialState,
@@ -526,6 +534,7 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
       const no_subscribed_in_feed = await db.getSetting(
         "no_subscribed_in_feed",
       );
+      const instances = await db.getSetting("instances");
 
       return {
         ...state.settings,
@@ -614,6 +623,7 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
         blocks: {
           keywords: filtered_keywords ?? initialState.blocks.keywords,
         },
+        instances: instances ?? initialState.instances,
       };
     });
 
@@ -665,6 +675,7 @@ export const {
   setPureBlack,
   setDefaultFeed,
   setNoSubscribedInFeed,
+  setInstances,
 } = appearanceSlice.actions;
 
 export default appearanceSlice.reducer;

--- a/src/features/user/LoggedOut.tsx
+++ b/src/features/user/LoggedOut.tsx
@@ -7,7 +7,7 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { useState } from "react";
 import { updateConnectedInstance } from "../auth/authSlice";
 import { swapHorizontalOutline } from "ionicons/icons";
-import { getCustomServers } from "../../services/app";
+import { useCustomServers } from "../../services/app";
 
 const Incognito = styled(IncognitoSvg)`
   opacity: 0.1;
@@ -20,6 +20,7 @@ const Incognito = styled(IncognitoSvg)`
 
 export default function LoggedOut() {
   const dispatch = useAppDispatch();
+  const [servers] = useCustomServers();
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance,
   );
@@ -59,7 +60,7 @@ export default function LoggedOut() {
         columns={[
           {
             name: "server",
-            options: getCustomServers().map((server) => ({
+            options: servers.map((server) => ({
               text: server,
               value: server,
             })),

--- a/src/pages/settings/ManageInstancesPage.tsx
+++ b/src/pages/settings/ManageInstancesPage.tsx
@@ -1,0 +1,45 @@
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonHeader,
+  IonPage,
+  IonTitle,
+  IonToolbar,
+} from "@ionic/react";
+import AppContent from "../../features/shared/AppContent";
+import ManageInstances from "../../features/settings/manage-instances/ManageInstances";
+import { useRef, useState } from "react";
+import { useSetActivePage } from "../../features/auth/AppContext";
+
+export default function ManageInstancesPage() {
+  const pageRef = useRef<HTMLElement>(null);
+  const [editing, setEditing] = useState(false);
+
+  useSetActivePage(pageRef);
+
+  return (
+    <IonPage ref={pageRef} className="grey-bg">
+      <IonHeader>
+        <IonToolbar>
+          <IonButtons slot="start">
+            <IonBackButton defaultHref="/settings" text="Settings" />
+          </IonButtons>
+
+          <IonTitle>Manage Instances</IonTitle>
+
+          <IonButtons slot="end">
+            {editing ? (
+              <IonButton onClick={() => setEditing(false)}>Done</IonButton>
+            ) : (
+              <IonButton onClick={() => setEditing(true)}>Edit</IonButton>
+            )}
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <AppContent scrollY>
+        <ManageInstances editing={editing} />
+      </AppContent>
+    </IonPage>
+  );
+}

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   colorPalette,
   heart,
   reloadCircle,
+  serverOutline,
 } from "ionicons/icons";
 import { useContext, useEffect, useRef } from "react";
 import { UpdateContext } from "./update/UpdateContext";
@@ -198,6 +199,12 @@ export default function SettingsPage() {
         </IonList>
 
         <IonList inset color="primary">
+          <InsetIonItem routerLink="/settings/manage-instances">
+            <IconBg color="color(display-p3 0.02 0.68 0.77)">
+              <IonIcon icon={serverOutline} />
+            </IconBg>
+            <SettingLabel>Manage instances</SettingLabel>
+          </InsetIonItem>
           <InsetIonItem routerLink="/settings/reddit-migrate">
             <IconBg color="#ff5700">
               <IonIcon icon={bagCheck} />

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -43,6 +43,7 @@ import {
 } from "../../features/settings/biometric/biometricSlice";
 import BiometricTitle from "../../features/settings/biometric/BiometricTitle";
 import usePageVisibility from "../../helpers/usePageVisibility";
+import { hasCustomServers } from "../../services/app";
 
 export const IconBg = styled.div<{ color: string; size?: string }>`
   width: 30px;
@@ -199,12 +200,14 @@ export default function SettingsPage() {
         </IonList>
 
         <IonList inset color="primary">
-          <InsetIonItem routerLink="/settings/manage-instances">
-            <IconBg color="color(display-p3 0.02 0.68 0.77)">
-              <IonIcon icon={serverOutline} />
-            </IconBg>
-            <SettingLabel>Manage instances</SettingLabel>
-          </InsetIonItem>
+          {!hasCustomServers() && (
+            <InsetIonItem routerLink="/settings/manage-instances">
+              <IconBg color="color(display-p3 0.02 0.68 0.77)">
+                <IonIcon icon={serverOutline} />
+              </IconBg>
+              <SettingLabel>Manage instances</SettingLabel>
+            </InsetIonItem>
+          )}
           <InsetIonItem routerLink="/settings/reddit-migrate">
             <IconBg color="#ff5700">
               <IonIcon icon={bagCheck} />

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { Dispatch, useEffect, useState } from "react";
 import { isNative } from "../helpers/device";
+import { useAppDispatch, useAppSelector } from "../store";
+import { setInstances } from "../features/settings/settingsSlice";
 
-const DEFAULT_LEMMY_SERVERS = [
+export const DEFAULT_LEMMY_SERVERS = [
   "lemmy.world",
   "lemmy.ml",
   "beehaw.org",
@@ -9,6 +11,17 @@ const DEFAULT_LEMMY_SERVERS = [
 ];
 
 let _customServers = DEFAULT_LEMMY_SERVERS;
+
+export function useCustomServers(): [string[], Dispatch<string[]>, () => void] {
+  const dispatch = useAppDispatch();
+  const customServers = useAppSelector((state) => state.settings.instances);
+  const setCustomServers = (servers: string[]) => {
+    dispatch(setInstances(servers));
+  };
+  const resetCustomServers = () => setCustomServers(DEFAULT_LEMMY_SERVERS);
+
+  return [customServers, setCustomServers, resetCustomServers];
+}
 
 export function getCustomServers() {
   return _customServers;

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -10,7 +10,7 @@ export const DEFAULT_LEMMY_SERVERS = [
   "sh.itjust.works",
 ];
 
-let _customServers = DEFAULT_LEMMY_SERVERS;
+let _customServers: string[] = [];
 
 export function useCustomServers(): [string[], Dispatch<string[]>, () => void] {
   const dispatch = useAppDispatch();
@@ -20,7 +20,12 @@ export function useCustomServers(): [string[], Dispatch<string[]>, () => void] {
   };
   const resetCustomServers = () => setCustomServers(DEFAULT_LEMMY_SERVERS);
 
+  if (hasCustomServers()) return [_customServers, () => {}, () => {}];
   return [customServers, setCustomServers, resetCustomServers];
+}
+
+export function hasCustomServers() {
+  return _customServers.length > 0;
 }
 
 export function getCustomServers() {
@@ -28,7 +33,7 @@ export function getCustomServers() {
 }
 
 export function getDefaultServer() {
-  return _customServers[0];
+  return _customServers[0] || DEFAULT_LEMMY_SERVERS[0];
 }
 
 async function getConfig() {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -279,6 +279,7 @@ export type SettingValueTypes = {
   no_subscribed_in_feed: boolean;
   infinite_scrolling: boolean;
   upvote_on_save: boolean;
+  instances: string[];
 };
 
 export interface ISettingItem<T extends keyof SettingValueTypes> {


### PR DESCRIPTION
Took a stab at #998. 

This adds a "Manage instances" screen to the Settings menu which allows editing the default list of Lemmy instances used by the app. Instances can be added and deleted, reordering is currently not implemented. There is a button to restore the default list in case the user messes up.

Newly added instances are verified to be Lemmy servers (using the `getSite()` call) before being added to the list. The list is stored in the database to make it persistent.

The Login and LoggedOut screens will now use the custom server list (this fixes #116). When choosing the "Other" option on the Login screen, if the login was successful, the instance will be added to the list automatically. 

As I mentioned in the issue discussion, I'm not entirely decided whether the "Manage instances" setting should be a top-level item or go into one of the existing categories, but of course this can be changed before merging. 

I'm also happy to change the particulars about where in the Redux state and the database the list is stored.

### Screenshot

<img width="300" alt="" src="https://github.com/aeharding/voyager/assets/98132670/29954aa3-63de-4359-9101-f5442b279910">
<img width="300" alt="" src="https://github.com/aeharding/voyager/assets/98132670/b39998f5-a3c1-4587-a0c8-a469ce1b2532">
<img width="300" alt="" src="https://github.com/aeharding/voyager/assets/98132670/d3c7f69d-e4ca-4f69-bb0a-fdf558aa533f">
<img width="300" alt="" src="https://github.com/aeharding/voyager/assets/98132670/262cc179-ee6f-4f1c-92d5-ce7249413b2c">
