### PR TITLE
Add feed media placeholder

### DIFF
--- a/src/features/gallery/GalleryImg.tsx
+++ b/src/features/gallery/GalleryImg.tsx
@@ -1,10 +1,18 @@
-import { FocusEvent, KeyboardEvent, useContext, useRef } from "react";
+import {
+  FocusEvent,
+  HTMLProps,
+  KeyboardEvent,
+  forwardRef,
+  useContext,
+  useRef,
+} from "react";
 import "photoswipe/dist/photoswipe.css";
 import { PostView } from "lemmy-js-client";
 import { GalleryContext } from "./GalleryProvider";
 import { PreparedPhotoSwipeOptions } from "photoswipe";
 
-export interface GalleryImgProps {
+export interface GalleryImgProps
+  extends Omit<HTMLProps<HTMLImageElement>, "ref"> {
   src?: string;
   alt?: string;
   className?: string;
@@ -22,37 +30,38 @@ export const preventPhotoswipeGalleryFocusTrap = {
   onKeyDown: (e: KeyboardEvent) => e.stopPropagation(),
 };
 
-export function GalleryImg({
-  src,
-  alt,
-  className,
-  post,
-  animationType,
-}: GalleryImgProps) {
-  const loaded = useRef(false);
-  const imgRef = useRef<HTMLImageElement>(null);
-  const { open } = useContext(GalleryContext);
+export default forwardRef<HTMLImageElement, GalleryImgProps>(
+  function GalleryImg(
+    { src, alt, className, post, animationType, ...rest },
+    imgRef,
+  ) {
+    const loaded = useRef(false);
+    const { open } = useContext(GalleryContext);
 
-  return (
-    <img
-      ref={imgRef}
-      draggable="false"
-      alt={alt}
-      onClick={(e) => {
-        if (!loaded.current) return;
+    return (
+      <img
+        {...rest}
+        ref={imgRef}
+        draggable="false"
+        alt={alt}
+        onClick={(e) => {
+          if (!loaded.current) return;
 
-        e.stopPropagation();
+          e.stopPropagation();
 
-        open(e.currentTarget, post, animationType);
-      }}
-      src={src}
-      className={className}
-      onLoad={(e) => {
-        if (!(e.target instanceof HTMLImageElement)) return;
-        if (!src) return;
+          open(e.currentTarget, post, animationType);
+        }}
+        src={src}
+        className={className}
+        onLoad={(e) => {
+          rest.onLoad?.(e);
 
-        loaded.current = true;
-      }}
-    />
-  );
-}
+          if (!(e.target instanceof HTMLImageElement)) return;
+          if (!src) return;
+
+          loaded.current = true;
+        }}
+      />
+    );
+  },
+);

--- a/src/features/gallery/PostMedia.tsx
+++ b/src/features/gallery/PostMedia.tsx
@@ -3,22 +3,35 @@ import { findLoneImage } from "../../helpers/markdown";
 import GalleryImg, { GalleryImgProps } from "./GalleryImg";
 import { isUrlMedia, isUrlVideo } from "../../helpers/url";
 import Video, { VideoProps } from "../shared/Video";
-import { forwardRef } from "react";
+import { RefObject, forwardRef, memo } from "react";
 
 export interface PostGalleryImgProps
   extends Omit<GalleryImgProps & VideoProps, "src"> {
   post: PostView;
 }
 
-export default forwardRef<HTMLImageElement, PostGalleryImgProps>(
-  function PostMedia({ post, ...props }, ref) {
-    const src = getPostMedia(post);
+const PostMedia = forwardRef<
+  HTMLVideoElement | HTMLImageElement,
+  PostGalleryImgProps
+>(function PostMedia({ post, ...props }, ref) {
+  const src = getPostMedia(post);
 
-    if (src && isUrlVideo(src)) return <Video src={src} {...props} />;
+  if (src && isUrlVideo(src))
+    return (
+      <Video ref={ref as RefObject<HTMLVideoElement>} src={src} {...props} />
+    );
 
-    return <GalleryImg {...props} ref={ref} src={src} post={post} />;
-  },
-);
+  return (
+    <GalleryImg
+      {...props}
+      ref={ref as RefObject<HTMLImageElement>}
+      src={src}
+      post={post}
+    />
+  );
+});
+
+export default memo(PostMedia);
 
 export function getPostMedia(post: PostView): string | undefined {
   if (post.post.url && isUrlMedia(post.post.url)) return post.post.url;

--- a/src/features/gallery/PostMedia.tsx
+++ b/src/features/gallery/PostMedia.tsx
@@ -1,23 +1,26 @@
 import { PostView } from "lemmy-js-client";
 import { findLoneImage } from "../../helpers/markdown";
-import { GalleryImg, GalleryImgProps } from "./GalleryImg";
+import GalleryImg, { GalleryImgProps } from "./GalleryImg";
 import { isUrlMedia, isUrlVideo } from "../../helpers/url";
 import Video, { VideoProps } from "../shared/Video";
+import { forwardRef } from "react";
 
 export interface PostGalleryImgProps
   extends Omit<GalleryImgProps & VideoProps, "src"> {
   post: PostView;
 }
 
-export default function PostMedia({ post, ...props }: PostGalleryImgProps) {
-  const src = getPostMedia(post);
+export default forwardRef<HTMLImageElement, PostGalleryImgProps>(
+  function PostMedia({ post, ...props }, ref) {
+    const src = getPostMedia(post);
 
-  if (src && isUrlVideo(src)) return <Video src={src} {...props} />;
+    if (src && isUrlVideo(src)) return <Video src={src} {...props} />;
 
-  return <GalleryImg {...props} src={src} post={post} />;
-}
+    return <GalleryImg {...props} ref={ref} src={src} post={post} />;
+  },
+);
 
-function getPostMedia(post: PostView): string | undefined {
+export function getPostMedia(post: PostView): string | undefined {
   if (post.post.url && isUrlMedia(post.post.url)) return post.post.url;
 
   if (post.post.thumbnail_url) return post.post.thumbnail_url;

--- a/src/features/post/inFeed/large/Image.tsx
+++ b/src/features/post/inFeed/large/Image.tsx
@@ -1,8 +1,15 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import PostMedia from "../../../gallery/PostMedia";
+import PostMedia, { PostGalleryImgProps } from "../../../gallery/PostMedia";
+import { useEffect, useRef, useState } from "react";
+import { IonIcon } from "@ionic/react";
+import { imageOutline, warningOutline } from "ionicons/icons";
 
-export const InFeedPostMedia = styled(PostMedia)<{ blur: boolean }>`
+interface ImgProps {
+  blur: boolean;
+}
+
+const Img = styled(PostMedia)<ImgProps>`
   width: 100%;
   max-width: none;
   max-height: max(100vh, 1000px);
@@ -18,3 +25,87 @@ export const InFeedPostMedia = styled(PostMedia)<{ blur: boolean }>`
       transform: translate3d(0, 0, 0);
     `}
 `;
+
+const PlaceholderContainer = styled.div<{ loaded: boolean }>`
+  ${({ loaded }) =>
+    !loaded &&
+    css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      aspect-ratio: 1.2;
+      position: relative;
+
+      img {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+      }
+    `}
+`;
+
+const LoadingIonIcon = styled(IonIcon)`
+  opacity: 0.5;
+  font-size: 24px;
+`;
+
+export default function Image(props: PostGalleryImgProps & ImgProps) {
+  const [imgRef, loaded, setLoaded] = useImgLoadObserver();
+  const [error, setError] = useState(false);
+
+  function renderIcon() {
+    if (error) return <LoadingIonIcon icon={warningOutline} />;
+    if (!loaded) return <LoadingIonIcon icon={imageOutline} />;
+  }
+
+  return (
+    <PlaceholderContainer loaded={loaded}>
+      <Img
+        {...props}
+        ref={imgRef}
+        style={{ display: error ? "none" : undefined }}
+        onError={() => {
+          setError(true);
+        }}
+        onLoad={() => {
+          setLoaded(true);
+        }}
+      />
+
+      {renderIcon()}
+    </PlaceholderContainer>
+  );
+}
+
+function useImgLoadObserver() {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [loaded, setLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleResize = (entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        if (
+          !(entry.target instanceof HTMLImageElement) ||
+          !entry.target.naturalWidth
+        )
+          return;
+
+        setLoaded(true);
+      }
+    };
+
+    if (!imgRef.current) return;
+
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(imgRef.current);
+
+    return () => {
+      // Cleanup: Disconnect the ResizeObserver when the component unmounts
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  return [imgRef, loaded, setLoaded] as const;
+}

--- a/src/features/post/inFeed/large/LargePost.tsx
+++ b/src/features/post/inFeed/large/LargePost.tsx
@@ -15,7 +15,7 @@ import { AnnouncementIcon } from "../../../../pages/posts/PostPage";
 import CommunityLink from "../../../labels/links/CommunityLink";
 import { PostProps } from "../Post";
 import Save from "../../../labels/Save";
-import { InFeedPostMedia } from "./Image";
+import Image from "./Image";
 import { useAppSelector } from "../../../../store";
 import { isUrlMedia } from "../../../../helpers/url";
 import ModeratableItem, {
@@ -127,7 +127,7 @@ export default function LargePost({
     if ((post.post.url && isUrlMedia(post.post.url)) || markdownLoneImage) {
       return (
         <ImageContainer>
-          <InFeedPostMedia
+          <Image
             blur={isNsfwBlurred(post, blurNsfw)}
             post={post}
             animationType="zoom"

--- a/src/features/post/inFeed/large/LargePost.tsx
+++ b/src/features/post/inFeed/large/LargePost.tsx
@@ -15,7 +15,7 @@ import { AnnouncementIcon } from "../../../../pages/posts/PostPage";
 import CommunityLink from "../../../labels/links/CommunityLink";
 import { PostProps } from "../Post";
 import Save from "../../../labels/Save";
-import Image from "./Image";
+import Media from "./Media";
 import { useAppSelector } from "../../../../store";
 import { isUrlMedia } from "../../../../helpers/url";
 import ModeratableItem, {
@@ -127,7 +127,7 @@ export default function LargePost({
     if ((post.post.url && isUrlMedia(post.post.url)) || markdownLoneImage) {
       return (
         <ImageContainer>
-          <Image
+          <Media
             blur={isNsfwBlurred(post, blurNsfw)}
             post={post}
             animationType="zoom"

--- a/src/features/post/inFeed/large/Media.tsx
+++ b/src/features/post/inFeed/large/Media.tsx
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import PostMedia, { PostGalleryImgProps } from "../../../gallery/PostMedia";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { IonIcon } from "@ionic/react";
 import { imageOutline, warningOutline } from "ionicons/icons";
+import useMediaLoadObserver from "./useMediaLoadObserver";
 
 interface ImgProps {
   blur: boolean;
@@ -37,7 +38,7 @@ const PlaceholderContainer = styled.div<{ loaded: boolean }>`
       aspect-ratio: 1.2;
       position: relative;
 
-      img {
+      ${Img} {
         position: absolute;
         top: 0;
         left: 0;
@@ -51,8 +52,8 @@ const LoadingIonIcon = styled(IonIcon)`
   font-size: 24px;
 `;
 
-export default function Image(props: PostGalleryImgProps & ImgProps) {
-  const [imgRef, loaded, setLoaded] = useImgLoadObserver();
+export default function Media(props: PostGalleryImgProps & ImgProps) {
+  const [mediaRef, loaded, setLoaded] = useMediaLoadObserver();
   const [error, setError] = useState(false);
 
   function renderIcon() {
@@ -64,7 +65,7 @@ export default function Image(props: PostGalleryImgProps & ImgProps) {
     <PlaceholderContainer loaded={loaded}>
       <Img
         {...props}
-        ref={imgRef}
+        ref={mediaRef}
         style={{ display: error ? "none" : undefined }}
         onError={() => {
           setError(true);
@@ -77,35 +78,4 @@ export default function Image(props: PostGalleryImgProps & ImgProps) {
       {renderIcon()}
     </PlaceholderContainer>
   );
-}
-
-function useImgLoadObserver() {
-  const imgRef = useRef<HTMLImageElement>(null);
-  const [loaded, setLoaded] = useState<boolean>(false);
-
-  useEffect(() => {
-    const handleResize = (entries: ResizeObserverEntry[]) => {
-      for (const entry of entries) {
-        if (
-          !(entry.target instanceof HTMLImageElement) ||
-          !entry.target.naturalWidth
-        )
-          return;
-
-        setLoaded(true);
-      }
-    };
-
-    if (!imgRef.current) return;
-
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(imgRef.current);
-
-    return () => {
-      // Cleanup: Disconnect the ResizeObserver when the component unmounts
-      resizeObserver.disconnect();
-    };
-  }, []);
-
-  return [imgRef, loaded, setLoaded] as const;
 }

--- a/src/features/post/inFeed/large/useMediaLoadObserver.ts
+++ b/src/features/post/inFeed/large/useMediaLoadObserver.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+
+export default function useMediaLoadObserver() {
+  const mediaRef = useRef<HTMLVideoElement | HTMLImageElement>(null);
+  const [loaded, _setLoaded] = useState(false);
+  const resizeObserverRef = useRef<ResizeObserver | undefined>();
+
+  useEffect(() => {
+    const handleResize = (entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        if (
+          (entry.target instanceof HTMLImageElement &&
+            entry.target.naturalWidth) ||
+          (entry.target instanceof HTMLVideoElement && entry.target.videoWidth)
+        ) {
+          setLoaded(true);
+          destroyObserver();
+          return;
+        }
+      }
+    };
+
+    if (!mediaRef.current) return;
+
+    resizeObserverRef.current = new ResizeObserver(handleResize);
+
+    resizeObserverRef.current.observe(mediaRef.current);
+
+    return destroyObserver;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function setLoaded(loaded: boolean) {
+    _setLoaded(loaded);
+    destroyObserver();
+  }
+
+  function destroyObserver() {
+    resizeObserverRef.current?.disconnect();
+    resizeObserverRef.current = undefined;
+  }
+
+  return [mediaRef, loaded, setLoaded] as const;
+}

--- a/src/features/shared/MarkdownImg.tsx
+++ b/src/features/shared/MarkdownImg.tsx
@@ -1,6 +1,6 @@
 import { HTMLProps } from "react";
 import { isUrlVideo } from "../../helpers/url";
-import { GalleryImg, GalleryImgProps } from "../gallery/GalleryImg";
+import GalleryImg, { GalleryImgProps } from "../gallery/GalleryImg";
 import Video from "./Video";
 import { css } from "@emotion/react";
 
@@ -9,7 +9,7 @@ const smallStyles = css`
 `;
 
 interface MarkdownImgProps
-  extends HTMLProps<HTMLImageElement>,
+  extends Omit<HTMLProps<HTMLImageElement>, "ref">,
     GalleryImgProps {
   /**
    * Restrict height of media within comments (unrestricted in post body)


### PR DESCRIPTION
Also handle error states to not show default browser image/video error styles.

Using `ResizeObserver` instead of `onLoad` because image and video natural size can be known before the image or video is completely loaded.