### PR TITLE
Update HidingSettings.tsx to remove the double occurance of inside in the helper text of Marking Read/Hiding settings

### DIFF
--- a/src/features/settings/general/hiding/HidingSettings.tsx
+++ b/src/features/settings/general/hiding/HidingSettings.tsx
@@ -36,7 +36,7 @@ export default function HidingSettings() {
           <HelperText>
             Auto Hide will automatically hide read posts when you refresh the
             feed. &quot;Disable in Communities&quot; stops posts from being
-            automatically hidden when read inside inside a feed for a specific
+            automatically hidden when read inside a feed for a specific
             community.
           </HelperText>
         </>


### PR DESCRIPTION
I know its a trivial commit but @aeharding you offered us the oppurtunity to do it so here it is.