### PR TITLE
feat: Quick account switcher

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -139,7 +139,7 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
     if (scrollUpIfNeeded(activePageRef?.current)) return;
 
     // if the profile page is already open, show the account switcher
-    if (router.getRouteInfo()?.pathname === "/profile")
+    if (location.pathname === "/profile")
       presentAccountSwitcher({ cssClass: "small" });
 
     router.push("/profile", "back");

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -12,7 +12,6 @@ import {
   IonLabel,
   IonTabBar,
   IonTabButton,
-  useIonModal,
 } from "@ionic/react";
 import { totalUnreadSelector } from "./features/inbox/inboxSlice";
 import useShouldInstall from "./features/pwa/useShouldInstall";
@@ -32,7 +31,7 @@ import { forwardRef, useContext, useEffect, useMemo } from "react";
 import { getDefaultServer } from "./services/app";
 import { focusSearchBar } from "./pages/search/SearchPage";
 import { useOptimizedIonRouter } from "./helpers/useOptimizedIonRouter";
-import AccountSwitcher from "./features/auth/AccountSwitcher";
+import { PageContext } from "./features/auth/PageContext";
 
 const Interceptor = styled.div`
   position: absolute;
@@ -65,6 +64,7 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
   const shouldInstall = useShouldInstall();
 
   const { activePageRef } = useContext(AppContext);
+  const { presentAccountSwitcher } = useContext(PageContext);
 
   const jwt = useAppSelector(jwtSelector);
   const totalUnread = useAppSelector(totalUnreadSelector);
@@ -85,15 +85,6 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
   const profileTabLabel = useMemo(
     () => getProfileTabLabel(profileLabelType, userHandle, connectedInstance),
     [profileLabelType, userHandle, connectedInstance],
-  );
-
-  const [presentAccountSwitcher, onDismissAccountSwitcher] = useIonModal(
-    AccountSwitcher,
-    {
-      onDismiss: (data: string, role: string) =>
-        onDismissAccountSwitcher(data, role),
-      activePageRef,
-    },
   );
 
   const isPostsButtonDisabled = location.pathname.startsWith("/posts");

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -12,6 +12,7 @@ import {
   IonLabel,
   IonTabBar,
   IonTabButton,
+  useIonModal,
 } from "@ionic/react";
 import { totalUnreadSelector } from "./features/inbox/inboxSlice";
 import useShouldInstall from "./features/pwa/useShouldInstall";
@@ -31,6 +32,7 @@ import { forwardRef, useContext, useEffect, useMemo } from "react";
 import { getDefaultServer } from "./services/app";
 import { focusSearchBar } from "./pages/search/SearchPage";
 import { useOptimizedIonRouter } from "./helpers/useOptimizedIonRouter";
+import AccountSwitcher from "./features/auth/AccountSwitcher";
 
 const Interceptor = styled.div`
   position: absolute;
@@ -85,6 +87,15 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
     [profileLabelType, userHandle, connectedInstance],
   );
 
+  const [presentAccountSwitcher, onDismissAccountSwitcher] = useIonModal(
+    AccountSwitcher,
+    {
+      onDismiss: (data: string, role: string) =>
+        onDismissAccountSwitcher(data, role),
+      activePageRef,
+    },
+  );
+
   const isPostsButtonDisabled = location.pathname.startsWith("/posts");
   const isInboxButtonDisabled = location.pathname.startsWith("/inbox");
   const isProfileButtonDisabled = location.pathname.startsWith("/profile");
@@ -135,6 +146,10 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
     if (!isProfileButtonDisabled) return;
 
     if (scrollUpIfNeeded(activePageRef?.current)) return;
+
+    // if the profile page is already open, show the account switcher
+    if (router.getRouteInfo()?.pathname === "/profile")
+      presentAccountSwitcher({ cssClass: "small" });
 
     router.push("/profile", "back");
   }

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -139,8 +139,7 @@ const TabBar: CustomTabBarType = forwardRef(function TabBar(props, ref) {
     if (scrollUpIfNeeded(activePageRef?.current)) return;
 
     // if the profile page is already open, show the account switcher
-    if (location.pathname === "/profile")
-      presentAccountSwitcher({ cssClass: "small" });
+    if (location.pathname === "/profile") presentAccountSwitcher();
 
     router.push("/profile", "back");
   }

--- a/src/features/auth/AccountSwitcher.tsx
+++ b/src/features/auth/AccountSwitcher.tsx
@@ -9,23 +9,21 @@ import {
   IonRadioGroup,
   IonTitle,
   IonToolbar,
-  useIonModal,
 } from "@ionic/react";
 import { add } from "ionicons/icons";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { changeAccount } from "./authSlice";
-import Login from "./Login";
-import { RefObject, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Account from "./Account";
 
 interface AccountSwitcherProps {
   onDismiss: (data?: string, role?: string) => void;
-  pageRef: RefObject<HTMLElement | undefined>;
+  presentLogin: () => void;
 }
 
 export default function AccountSwitcher({
   onDismiss,
-  pageRef,
+  presentLogin,
 }: AccountSwitcherProps) {
   const dispatch = useAppDispatch();
   const accounts = useAppSelector((state) => state.auth.accountData?.accounts);
@@ -33,11 +31,6 @@ export default function AccountSwitcher({
     (state) => state.auth.accountData?.activeHandle,
   );
   const [editing, setEditing] = useState(false);
-
-  // Modals don't access to PageContext, so just inject the login modal manually
-  const [login, onDismissLogin] = useIonModal(Login, {
-    onDismiss: (data: string, role: string) => onDismissLogin(data, role),
-  });
 
   useEffect(() => {
     if (accounts?.length) return;
@@ -52,11 +45,7 @@ export default function AccountSwitcher({
         <IonToolbar>
           <IonButtons slot="start">
             {editing ? (
-              <IonButton
-                onClick={() =>
-                  login({ presentingElement: pageRef.current ?? undefined })
-                }
-              >
+              <IonButton onClick={() => presentLogin()}>
                 <IonIcon icon={add} />
               </IonButton>
             ) : (

--- a/src/features/auth/PageContext.tsx
+++ b/src/features/auth/PageContext.tsx
@@ -98,14 +98,17 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     },
   );
 
-  const presentLoginIfNeeded = useCallback(() => {
-    if (jwt) return false;
+  const presentLoginIfNeeded = useCallback(
+    (force = false) => {
+      if (!force && jwt) return false;
 
-    presentLogin({
-      presentingElement: value.pageRef?.current ?? undefined,
-    });
-    return true;
-  }, [jwt, presentLogin, value.pageRef]);
+      presentLogin({
+        presentingElement: value.pageRef?.current ?? undefined,
+      });
+      return true;
+    },
+    [jwt, presentLogin, value.pageRef],
+  );
 
   const presentShareAsImage = useCallback(
     (post: PostView, comment?: CommentView, comments?: CommentView[]) => {
@@ -194,7 +197,7 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     {
       onDismiss: (data: string, role: string) =>
         onDismissAccountSwitcher(data, role),
-      pageRef: value,
+      presentLogin: () => presentLoginIfNeeded(true),
     },
   );
 

--- a/src/features/auth/PageContext.tsx
+++ b/src/features/auth/PageContext.tsx
@@ -1,5 +1,4 @@
-import { ModalOptions, useIonModal } from "@ionic/react";
-import { ComponentRef } from "@ionic/core";
+import { useIonModal } from "@ionic/react";
 import React, {
   RefObject,
   createContext,
@@ -22,7 +21,6 @@ import SelectTextModal from "../../pages/shared/SelectTextModal";
 import ShareAsImageModal, {
   ShareAsImageData,
 } from "../share/asImage/ShareAsImageModal";
-import { HookOverlayOptions } from "@ionic/react/dist/types/hooks/HookOverlayOptions";
 import AccountSwitcher from "./AccountSwitcher";
 
 interface IPageContext {
@@ -63,12 +61,7 @@ interface IPageContext {
     comments?: CommentView[],
   ) => void;
 
-  presentAccountSwitcher: (
-    options?:
-      | (Omit<ModalOptions<ComponentRef>, "component" | "componentProps"> &
-          HookOverlayOptions)
-      | undefined,
-  ) => void;
+  presentAccountSwitcher: () => void;
 }
 
 export const PageContext = createContext<IPageContext>({
@@ -196,7 +189,7 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     reportRef.current?.present(item);
   }, []);
 
-  const [presentAccountSwitcher, onDismissAccountSwitcher] = useIonModal(
+  const [presentAccountSwitcherModal, onDismissAccountSwitcher] = useIonModal(
     AccountSwitcher,
     {
       onDismiss: (data: string, role: string) =>
@@ -204,6 +197,10 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
       pageRef: value,
     },
   );
+
+  const presentAccountSwitcher = useCallback(() => {
+    presentAccountSwitcherModal({ cssClass: "small" });
+  }, [presentAccountSwitcherModal]);
 
   const currentValue = useMemo(
     () => ({

--- a/src/features/auth/PageContext.tsx
+++ b/src/features/auth/PageContext.tsx
@@ -98,17 +98,14 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     },
   );
 
-  const presentLoginIfNeeded = useCallback(
-    (force = false) => {
-      if (!force && jwt) return false;
+  const presentLoginIfNeeded = useCallback(() => {
+    if (jwt) return false;
 
-      presentLogin({
-        presentingElement: value.pageRef?.current ?? undefined,
-      });
-      return true;
-    },
-    [jwt, presentLogin, value.pageRef],
-  );
+    presentLogin({
+      presentingElement: value.pageRef?.current ?? undefined,
+    });
+    return true;
+  }, [jwt, presentLogin, value.pageRef]);
 
   const presentShareAsImage = useCallback(
     (post: PostView, comment?: CommentView, comments?: CommentView[]) => {
@@ -197,7 +194,10 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     {
       onDismiss: (data: string, role: string) =>
         onDismissAccountSwitcher(data, role),
-      presentLogin: () => presentLoginIfNeeded(true),
+      presentLogin: () =>
+        presentLogin({
+          presentingElement: value.pageRef?.current ?? undefined,
+        }),
     },
   );
 

--- a/src/features/auth/PageContext.tsx
+++ b/src/features/auth/PageContext.tsx
@@ -1,4 +1,5 @@
-import { useIonModal } from "@ionic/react";
+import { ModalOptions, useIonModal } from "@ionic/react";
+import { ComponentRef } from "@ionic/core";
 import React, {
   RefObject,
   createContext,
@@ -21,6 +22,8 @@ import SelectTextModal from "../../pages/shared/SelectTextModal";
 import ShareAsImageModal, {
   ShareAsImageData,
 } from "../share/asImage/ShareAsImageModal";
+import { HookOverlayOptions } from "@ionic/react/dist/types/hooks/HookOverlayOptions";
+import AccountSwitcher from "./AccountSwitcher";
 
 interface IPageContext {
   // used for ion presentingElement
@@ -59,6 +62,13 @@ interface IPageContext {
     comment?: CommentView,
     comments?: CommentView[],
   ) => void;
+
+  presentAccountSwitcher: (
+    options?:
+      | (Omit<ModalOptions<ComponentRef>, "component" | "componentProps"> &
+          HookOverlayOptions)
+      | undefined,
+  ) => void;
 }
 
 export const PageContext = createContext<IPageContext>({
@@ -70,6 +80,7 @@ export const PageContext = createContext<IPageContext>({
   presentPostEditor: () => {},
   presentSelectText: () => {},
   presentShareAsImage: () => {},
+  presentAccountSwitcher: () => {},
 });
 
 interface PageContextProvider {
@@ -185,6 +196,15 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
     reportRef.current?.present(item);
   }, []);
 
+  const [presentAccountSwitcher, onDismissAccountSwitcher] = useIonModal(
+    AccountSwitcher,
+    {
+      onDismiss: (data: string, role: string) =>
+        onDismissAccountSwitcher(data, role),
+      pageRef: value,
+    },
+  );
+
   const currentValue = useMemo(
     () => ({
       ...value,
@@ -195,6 +215,7 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
       presentPostEditor,
       presentSelectText,
       presentShareAsImage,
+      presentAccountSwitcher,
     }),
     [
       presentCommentEdit,
@@ -204,6 +225,7 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
       presentReport,
       presentSelectText,
       presentShareAsImage,
+      presentAccountSwitcher,
       value,
     ],
   );

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -27,9 +27,7 @@ export default function ProfilePage() {
           {handle ? (
             <>
               <IonButtons slot="start">
-                <IonButton
-                  onClick={() => presentAccountSwitcher({ cssClass: "small" })}
-                >
+                <IonButton onClick={() => presentAccountSwitcher()}>
                   Accounts
                 </IonButton>
               </IonButtons>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -5,13 +5,11 @@ import {
   IonPage,
   IonTitle,
   IonToolbar,
-  useIonModal,
 } from "@ionic/react";
 import AsyncProfile from "../../features/user/AsyncProfile";
 import { useAppSelector } from "../../store";
 import { handleSelector } from "../../features/auth/authSlice";
 import LoggedOut from "../../features/user/LoggedOut";
-import AccountSwitcher from "../../features/auth/AccountSwitcher";
 import { useContext } from "react";
 import AppContent from "../../features/shared/AppContent";
 import { PageContext } from "../../features/auth/PageContext";
@@ -19,16 +17,8 @@ import FeedContent from "../shared/FeedContent";
 
 export default function ProfilePage() {
   const handle = useAppSelector(handleSelector);
-  const { pageRef, presentLoginIfNeeded } = useContext(PageContext);
-
-  const [presentAccountSwitcher, onDismissAccountSwitcher] = useIonModal(
-    AccountSwitcher,
-    {
-      onDismiss: (data: string, role: string) =>
-        onDismissAccountSwitcher(data, role),
-      pageRef,
-    },
-  );
+  const { presentAccountSwitcher, presentLoginIfNeeded } =
+    useContext(PageContext);
 
   return (
     <IonPage className="grey-bg">


### PR DESCRIPTION
Since #715 has blocked and inactive for a while, and I really miss this feature from Apollo, I thought I'd try my own version of this.

This makes tapping the Profile button in the tab bar pull up the account switcher IF the profile page is already active in the profile tab (and hasn't been scrolled down on).

This means tapping the Profile button TWICE will bring up the account switcher also.

If you open the Profile page by tapping the button once, and then navigate away by clicking one of the links on it, tapping the profile button again will bring you back to the profile page, as before.

https://github.com/aeharding/voyager/assets/98132670/1f41e4db-5917-44bb-ac38-1c94948861b5
