### PR TITLE
Feature: Crossposting

### DIFF
--- a/src/features/auth/PageContext.tsx
+++ b/src/features/auth/PageContext.tsx
@@ -13,7 +13,7 @@ import Login from "../auth/Login";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { changeAccount, jwtSelector } from "../auth/authSlice";
 import CommentReplyModal from "../comment/compose/reply/CommentReplyModal";
-import { Comment, CommentView, PostView } from "lemmy-js-client";
+import { Comment, CommentView, Community, PostView } from "lemmy-js-client";
 import CommentEditModal from "../comment/compose/edit/CommentEditModal";
 import { Report, ReportHandle, ReportableItem } from "../report/Report";
 import PostEditorModal from "../post/new/PostEditorModal";
@@ -51,7 +51,7 @@ interface IPageContext {
    * @param postOrCommunity An existing post to be edited, or the community handle
    * to submit the new post to
    */
-  presentPostEditor: (postOrCommunity: PostView | string) => void;
+  presentPostEditor: (post?: PostView, community?: Community | string) => void;
 
   presentSelectText: (text: string) => void;
 
@@ -166,11 +166,13 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
   // Edit comment end
 
   // Edit/new post start
-  const postItem = useRef<PostView | string>();
+  const postItem = useRef<PostView>();
+  const communityRef = useRef<Community | string>();
   const [isPostOpen, setIsPostOpen] = useState(false);
   const presentPostEditor = useCallback(
-    (postOrCommunity: PostView | string) => {
-      postItem.current = postOrCommunity;
+    (post?: PostView, community?: Community | string) => {
+      postItem.current = post;
+      communityRef.current = community;
       setIsPostOpen(true);
     },
     [],
@@ -255,7 +257,8 @@ export function PageContextProvider({ value, children }: PageContextProvider) {
       <Report ref={reportRef} />
       <PostEditorModal
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        postOrCommunity={postItem.current!}
+        post={postItem.current!}
+        community={communityRef.current!}
         isOpen={isPostOpen}
         setIsOpen={setIsPostOpen}
       />

--- a/src/features/community/useCommunityActions.tsx
+++ b/src/features/community/useCommunityActions.tsx
@@ -97,7 +97,7 @@ export default function useCommunityActions(
       return;
     }
 
-    presentPostEditor(communityHandle);
+    presentPostEditor(undefined, communityHandle);
   }
 
   async function _block() {

--- a/src/features/post/new/PostEditor.tsx
+++ b/src/features/post/new/PostEditor.tsx
@@ -1,19 +1,15 @@
 import { IonNav } from "@ionic/react";
-import { CommunityView, PostView } from "lemmy-js-client";
+import { Community, PostView } from "lemmy-js-client";
 import PostEditorRoot from "./PostEditorRoot";
 import { useCallback } from "react";
 
 export type PostEditorProps = {
   setCanDismiss: (canDismiss: boolean) => void;
   dismiss: () => void;
-} & (
-  | {
-      community: CommunityView | undefined;
-    }
-  | {
-      existingPost: PostView;
-    }
-);
+} & {
+  community: Community | undefined;
+  existingPost: PostView | undefined;
+};
 
 export default function PostEditor(props: PostEditorProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/post/new/PostEditorModal.tsx
+++ b/src/features/post/new/PostEditorModal.tsx
@@ -1,31 +1,24 @@
 import PostEditor from "./PostEditor";
 import { useAppSelector } from "../../../store";
 import { DynamicDismissableModal } from "../../shared/DynamicDismissableModal";
-import { PostView } from "lemmy-js-client";
+import { Community, PostView } from "lemmy-js-client";
 
 interface PostEditorModalProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
-  postOrCommunity: PostView | string;
+  post?: PostView;
+  community?: Community | string;
 }
 
 export default function PostEditorModal({
   isOpen,
   setIsOpen,
-  postOrCommunity,
+  post,
+  community,
 }: PostEditorModalProps) {
   const communityByHandle = useAppSelector(
     (state) => state.community.communityByHandle,
   );
-
-  const editOrCreateProps =
-    typeof postOrCommunity === "string"
-      ? {
-          community: communityByHandle[postOrCommunity],
-        }
-      : {
-          existingPost: postOrCommunity,
-        };
 
   return (
     <DynamicDismissableModal isOpen={isOpen} setIsOpen={setIsOpen}>
@@ -33,7 +26,12 @@ export default function PostEditorModal({
         <PostEditor
           setCanDismiss={setCanDismiss}
           dismiss={dismiss}
-          {...editOrCreateProps}
+          community={
+            typeof community === "string"
+              ? communityByHandle[community]?.community
+              : community
+          }
+          existingPost={post}
         />
       )}
     </DynamicDismissableModal>

--- a/src/features/post/new/PostEditorRoot.tsx
+++ b/src/features/post/new/PostEditorRoot.tsx
@@ -285,7 +285,10 @@ export default function PostEditorRoot({
     dispatch(receivedPosts([postResponse.post_view]));
 
     presentToast({
-      message: existingPost ? "Post edited!" : "Post created!",
+      message: (() => {
+        if (existingPost?.community !== community) return "Crosspost created!";
+        return existingPost ? "Post edited!" : "Post created!";
+      })(),
       color: "primary",
       position: "top",
       centerText: true,

--- a/src/features/post/new/PostEditorRoot.tsx
+++ b/src/features/post/new/PostEditorRoot.tsx
@@ -22,7 +22,7 @@ import useClient from "../../../helpers/useClient";
 import { useAppDispatch, useAppSelector } from "../../../store";
 import { Centered, Spinner } from "../../auth/Login";
 import { jwtSelector, urlSelector } from "../../auth/authSlice";
-import { startCase } from "lodash";
+import { compact, startCase } from "lodash";
 import { css } from "@emotion/react";
 import { getHandle, getRemoteHandle } from "../../../helpers/lemmy";
 import { cameraOutline } from "ionicons/icons";
@@ -37,6 +37,7 @@ import { isUrlImage, isValidUrl } from "../../../helpers/url";
 import { problemFetchingTitle } from "../../../helpers/toastMessages";
 import { useOptimizedIonRouter } from "../../../helpers/useOptimizedIonRouter";
 import { isAndroid } from "../../../helpers/device";
+import { quote } from "../../../helpers/markdown";
 
 const Container = styled.div`
   position: absolute;
@@ -115,7 +116,15 @@ export default function PostEditorRoot({
 
   const initialUrl = initialImage ? "" : existingPost?.post.url ?? "";
 
-  const initialText = existingPost?.post.body ?? "";
+  const initialText = (() => {
+    if (existingPost && existingPost.community !== community)
+      return compact([
+        `cross-posted from: ${existingPost.post.ap_id}`,
+        existingPost.post.body && quote(existingPost.post.body),
+      ]).join("\n\n");
+
+    return existingPost?.post.body ?? "";
+  })();
 
   const initialNsfw = existingPost?.post.nsfw ?? false;
 

--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -22,3 +22,10 @@ export function findLoneImage(
 
   return null;
 }
+
+export function quote(markdown: string) {
+  return markdown
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}


### PR DESCRIPTION
## Summary

This adds the ability to crosspost existing posts to other communities, for feature parity with Apollo and Lemmy.

There is a new option called "Crosspost to..." in the "more actions" menu for posts, after the "Reply" option. When selected, it presents a community selector to allow the user to chose the community to crosspost to, and then opens the post editor with a copy of the original post, similar to how the Lemmy web client operates. The post body will contain a link to the original post, as well as the markdown-quoted original body (if available).

Icon choice is not necessarily final, [see here](https://github.com/aeharding/voyager/issues/84#issuecomment-1851465842) for possible alternatives.

This fixes #84. Comments and feedback welcome.

## Screenshots

<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/ef397f40-ebe7-49b7-90b9-15f9aaaa9f15">
<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/e087f357-422c-40d4-acf8-4001ad66adfb">
<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/83ae84eb-bfa4-4980-a0f3-634a2e9189f6">
<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/bf4989b7-2b68-4fc2-a62d-9488163ce734">

## Details

The `PostEditor` and all related components and functions now take two parameters, `post` and `community`, instead of one. Both are optional, but at least one is required. If a community is given but no post, a new post will be created in that community. If a post is given but no community, the post will be edited in-place. If both are given (and are different from each other), a copy of the post will be crossposted to the given community.