### PR TITLE
Fix tap to open video in feed

### DIFF
--- a/src/features/comment/CommentMarkdown.tsx
+++ b/src/features/comment/CommentMarkdown.tsx
@@ -25,7 +25,11 @@ export default function CommentMarkdown({ children }: CommentMarkdownProps) {
               {props.alt || "Image"}
             </InAppExternalLink>
           ) : (
-            <MarkdownImg small {...props} />
+            <MarkdownImg
+              small
+              onClick={(e) => e.stopPropagation()}
+              {...props}
+            />
           ),
       }}
     >

--- a/src/features/post/detail/PostHeader.tsx
+++ b/src/features/post/detail/PostHeader.tsx
@@ -201,9 +201,7 @@ function PostHeader({
         }}
       >
         <Container>
-          {showPostText && (
-            <div onClick={(e) => e.stopPropagation()}>{renderMedia()}</div>
-          )}
+          {showPostText && renderMedia()}
           <PostDeets>
             <ModeratableItemBannerOutlet />
             <div>

--- a/src/features/post/detail/PostHeader.tsx
+++ b/src/features/post/detail/PostHeader.tsx
@@ -156,6 +156,7 @@ function PostHeader({
           post={post}
           controls
           constrainHeight={constrainHeight}
+          onClick={(e) => e.stopPropagation()}
         />
       );
     }

--- a/src/features/shared/Markdown.tsx
+++ b/src/features/shared/Markdown.tsx
@@ -62,7 +62,9 @@ export default function Markdown(props: ReactMarkdownOptions) {
     <ReactMarkdown
       {...props}
       components={{
-        img: (props) => <MarkdownImg {...props} />,
+        img: (props) => (
+          <MarkdownImg onClick={(e) => e.stopPropagation()} {...props} />
+        ),
         blockquote: (props) => <Blockquote {...props} />,
         code: (props) => <Code {...props} />,
         table: (props) => (

--- a/src/features/shared/Video.tsx
+++ b/src/features/shared/Video.tsx
@@ -151,7 +151,6 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(function Video(
           if (!showProgress) return;
           setProgress(e.target.currentTime / e.target.duration);
         }}
-        onClick={(e) => e.stopPropagation()}
         {...rest}
       />
       {showProgress && progress !== undefined && <Progress value={progress} />}


### PR DESCRIPTION
This only worked in iOS incidentally due to a workaround for iOS <= 17.1 having broken video implementation