### PR TITLE
Fix posts failing to load in iOS lockdown mode

### DIFF
--- a/src/features/post/postSlice.ts
+++ b/src/features/post/postSlice.ts
@@ -203,7 +203,16 @@ export const receivedPosts = createAsyncThunk(
       };
 
     const receivedPostsIds = posts.map((post) => post.post.id);
-    const postMetadatas = await db.getPostMetadatas(receivedPostsIds, handle);
+
+    let postMetadatas: IPostMetadata[];
+
+    try {
+      postMetadatas = await db.getPostMetadatas(receivedPostsIds, handle);
+    } catch (error) {
+      // If lockdown mode or indexeddb unavailable, continue
+      postMetadatas = [];
+      console.error("Error fetching post metadatas", error);
+    }
 
     for (const postMetadata of postMetadatas) {
       postHiddenById[postMetadata.post_id] = !!postMetadata.hidden;

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -455,9 +455,15 @@ export const getDefaultFeed =
   () => async (dispatch: AppDispatch, getState: () => RootState) => {
     const userHandle = getState().auth.accountData?.activeHandle;
 
-    const defaultFeed = await db.getSetting("default_feed", {
-      user_handle: userHandle,
-    });
+    let defaultFeed;
+
+    try {
+      defaultFeed = await db.getSetting("default_feed", {
+        user_handle: userHandle,
+      });
+    } catch (error) {
+      console.error("Error receiving default feed", error);
+    }
 
     dispatch(setDefaultFeed(defaultFeed ?? { type: ODefaultFeedType.Home }));
   };


### PR DESCRIPTION
Settings will still not persist because iOS disables indexedDB in lockdown mode