### PR TITLE
Change post/comment editor abort action title to "Discard"

### DIFF
--- a/src/features/shared/DynamicDismissableModal.tsx
+++ b/src/features/shared/DynamicDismissableModal.tsx
@@ -51,7 +51,7 @@ export function DynamicDismissableModal({
 
     await presentActionSheet([
       {
-        text: "Delete",
+        text: "Discard",
         role: "destructive",
         handler: () => {
           clearRecoveredText();


### PR DESCRIPTION
When pressing "cancel" on a post or comment that has unsaved changes, the button to confirm deletion now says "Discard" instead of "Delete".

![image](https://github.com/aeharding/voyager/assets/98132670/1d887eb4-d134-4cfa-bcc3-f819015e1b76)

This fixes #1059.