### PR TITLE
Feature: Option to view profile pictures in comments

### DIFF
--- a/src/features/labels/links/PersonLink.tsx
+++ b/src/features/labels/links/PersonLink.tsx
@@ -6,7 +6,10 @@ import { Person } from "lemmy-js-client";
 import Handle from "../Handle";
 import { StyledLink, hideCss } from "./shared";
 import { useAppSelector } from "../../../store";
-import { OInstanceUrlDisplayMode } from "../../../services/db";
+import {
+  OInstanceUrlDisplayMode,
+  OUserAvatarDisplayMode,
+} from "../../../services/db";
 import AgeBadge from "./AgeBadge";
 import { useContext } from "react";
 import { ShareImageContext } from "../../share/asImage/ShareAsImage";
@@ -71,6 +74,11 @@ export default function PersonLink({
       (state) => state.settings.appearance.general.userInstanceUrlDisplay,
     ) === OInstanceUrlDisplayMode.WhenRemote;
 
+  const userAvatarDisplay =
+    useAppSelector(
+      (state) => state.settings.appearance.general.userAvatarDisplay,
+    ) === OUserAvatarDisplayMode.InComments;
+
   if (isAdmin) color = "var(--ion-color-danger)";
   else if (distinguished) color = "var(--ion-color-success)";
   else if (opId && person.id === opId) color = "var(--ion-color-primary-fixed)";
@@ -88,14 +96,16 @@ export default function PersonLink({
           <Prefix>{prefix}</Prefix>{" "}
         </>
       ) : (
-        <ItemIcon
-          item={person}
-          size={24}
-          css={css`
-            margin-right: 0.4rem;
-            vertical-align: middle;
-          `}
-        />
+        userAvatarDisplay && (
+          <ItemIcon
+            item={person}
+            size={24}
+            css={css`
+              margin-right: 0.4rem;
+              vertical-align: middle;
+            `}
+          />
+        )
       )}
       <Handle
         item={person}

--- a/src/features/labels/links/PersonLink.tsx
+++ b/src/features/labels/links/PersonLink.tsx
@@ -10,6 +10,7 @@ import { OInstanceUrlDisplayMode } from "../../../services/db";
 import AgeBadge from "./AgeBadge";
 import { useContext } from "react";
 import { ShareImageContext } from "../../share/asImage/ShareAsImage";
+import ItemIcon from "../img/ItemIcon";
 
 const Prefix = styled.span`
   font-weight: normal;
@@ -86,7 +87,16 @@ export default function PersonLink({
         <>
           <Prefix>{prefix}</Prefix>{" "}
         </>
-      ) : undefined}
+      ) : (
+        <ItemIcon
+          item={person}
+          size={24}
+          css={css`
+            margin-right: 0.4rem;
+            vertical-align: middle;
+          `}
+        />
+      )}
       <Handle
         item={person}
         showInstanceWhenRemote={showInstanceWhenRemote || forceInstanceUrl}

--- a/src/features/settings/appearance/General.tsx
+++ b/src/features/settings/appearance/General.tsx
@@ -1,8 +1,14 @@
 import { IonLabel, IonList, IonToggle } from "@ionic/react";
 import { InsetIonItem } from "../../../pages/profile/ProfileFeedItemsPage";
 import { useAppDispatch, useAppSelector } from "../../../store";
-import { setUserInstanceUrlDisplay } from "../settingsSlice";
-import { OInstanceUrlDisplayMode } from "../../../services/db";
+import {
+  setUserAvatarDisplay,
+  setUserInstanceUrlDisplay,
+} from "../settingsSlice";
+import {
+  OInstanceUrlDisplayMode,
+  OUserAvatarDisplayMode,
+} from "../../../services/db";
 import { ListHeader } from "../shared/formatting";
 
 export default function GeneralAppearance() {
@@ -10,6 +16,10 @@ export default function GeneralAppearance() {
 
   const userInstanceUrlDisplay = useAppSelector(
     (state) => state.settings.appearance.general.userInstanceUrlDisplay,
+  );
+
+  const userAvatarDisplay = useAppSelector(
+    (state) => state.settings.appearance.general.userAvatarDisplay,
   );
 
   return (
@@ -34,6 +44,22 @@ export default function GeneralAppearance() {
             }
           >
             Show user instance
+          </IonToggle>
+        </InsetIonItem>
+        <InsetIonItem>
+          <IonToggle
+            checked={userAvatarDisplay === OUserAvatarDisplayMode.InComments}
+            onIonChange={(e) =>
+              dispatch(
+                setUserAvatarDisplay(
+                  e.detail.checked
+                    ? OUserAvatarDisplayMode.InComments
+                    : OUserAvatarDisplayMode.Never,
+                ),
+              )
+            }
+          >
+            Show user avatars
           </IonToggle>
         </InsetIonItem>
       </IonList>

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -36,6 +36,8 @@ import {
   ODefaultFeedType,
   TapToCollapseType,
   OTapToCollapseType,
+  UserAvatarDisplayMode,
+  OUserAvatarDisplayMode,
 } from "../../services/db";
 import { get, set } from "./storage";
 import { Mode } from "@ionic/core";
@@ -59,6 +61,7 @@ interface SettingsState {
     };
     general: {
       userInstanceUrlDisplay: InstanceUrlDisplayMode;
+      userAvatarDisplay: UserAvatarDisplayMode;
       profileLabel: ProfileLabelType;
     };
     posts: {
@@ -136,6 +139,7 @@ const initialState: SettingsState = {
     },
     general: {
       userInstanceUrlDisplay: OInstanceUrlDisplayMode.Never,
+      userAvatarDisplay: OUserAvatarDisplayMode.Never,
       profileLabel: OProfileLabelType.Instance,
     },
     posts: {
@@ -247,6 +251,10 @@ export const appearanceSlice = createSlice({
     ) {
       state.appearance.general.userInstanceUrlDisplay = action.payload;
       db.setSetting("user_instance_url_display", action.payload);
+    },
+    setUserAvatarDisplay(state, action: PayloadAction<UserAvatarDisplayMode>) {
+      state.appearance.general.userAvatarDisplay = action.payload;
+      db.setSetting("user_avatar_display", action.payload);
     },
     setProfileLabel(state, action: PayloadAction<ProfileLabelType>) {
       state.appearance.general.profileLabel = action.payload;
@@ -509,6 +517,7 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
       const user_instance_url_display = await db.getSetting(
         "user_instance_url_display",
       );
+      const user_avatar_display = await db.getSetting("user_avatar_display");
       const profile_label = await db.getSetting("profile_label");
       const post_appearance_type = await db.getSetting("post_appearance_type");
       const blur_nsfw = await db.getSetting("blur_nsfw");
@@ -560,6 +569,9 @@ export const fetchSettingsFromDatabase = createAsyncThunk<SettingsState>(
             userInstanceUrlDisplay:
               user_instance_url_display ??
               initialState.appearance.general.userInstanceUrlDisplay,
+            userAvatarDisplay:
+              user_avatar_display ??
+              initialState.appearance.general.userAvatarDisplay,
             profileLabel:
               profile_label ?? initialState.appearance.general.profileLabel,
           },
@@ -660,6 +672,7 @@ export const {
   setFontSizeMultiplier,
   setUseSystemFontSize,
   setUserInstanceUrlDisplay,
+  setUserAvatarDisplay,
   setProfileLabel,
   setCommentsCollapsed,
   setTapToCollapse,

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -98,6 +98,14 @@ export const OInstanceUrlDisplayMode = {
 export type InstanceUrlDisplayMode =
   (typeof OInstanceUrlDisplayMode)[keyof typeof OInstanceUrlDisplayMode];
 
+export const OUserAvatarDisplayMode = {
+  InComments: "in-comments",
+  Never: "never",
+} as const;
+
+export type UserAvatarDisplayMode =
+  (typeof OUserAvatarDisplayMode)[keyof typeof OUserAvatarDisplayMode];
+
 export const OVoteDisplayMode = {
   /**
    * Show upvotes and downvotes separately
@@ -250,6 +258,7 @@ export type SwipeActions = Record<SwipeDirection, SwipeAction>;
 export type SettingValueTypes = {
   collapse_comment_threads: CommentThreadCollapse;
   user_instance_url_display: InstanceUrlDisplayMode;
+  user_avatar_display: UserAvatarDisplayMode;
   vote_display_mode: VoteDisplayMode;
   profile_label: ProfileLabelType;
   post_appearance_type: PostAppearanceType;


### PR DESCRIPTION
Adds a new option "Show avatars in comments" (default: OFF).

When enabled, user names in the comments will have their profile picture shown next to their names.

<img alt="screenshot" width="330" src="https://github.com/aeharding/voyager/assets/98132670/d6f89a94-e640-419e-bd35-0b6334160137">

<img alt="screenshot" width="330" src="https://github.com/aeharding/voyager/assets/98132670/391086ca-aa8d-45bb-869b-8e637407dd67">

This fixes #567.