### PR TITLE
Feature: remote content visibility detection

### DIFF
--- a/src/features/comment/Comment.tsx
+++ b/src/features/comment/Comment.tsx
@@ -22,6 +22,7 @@ import ModeratableItem from "../moderation/ModeratableItem";
 import useCanModerate from "../moderation/useCanModerate";
 import ModqueueItemActions from "../moderation/ModqueueItemActions";
 import { ActionsContainer } from "../post/inFeed/compact/CompactPost";
+import Visible from "../labels/Visible";
 
 const rainbowColors = [
   "#FF0000", // Red
@@ -256,6 +257,7 @@ export default function Comment({
                     />
                     <Vote item={commentView} />
                     <Edited item={commentView} />
+                    <Visible item={commentView} />
                     <div
                       css={css`
                         flex: 1;

--- a/src/features/labels/Visible.tsx
+++ b/src/features/labels/Visible.tsx
@@ -1,0 +1,70 @@
+import {
+  Comment,
+  CommentView,
+  Community,
+  Post,
+  PostView,
+} from "lemmy-js-client";
+import { IonIcon, useIonAlert } from "@ionic/react";
+import { warning } from "ionicons/icons";
+import { MouseEvent, useEffect, useState } from "react";
+import styled from "@emotion/styled";
+import { getItemActorName } from "../../helpers/lemmy";
+import { getClient } from "../../services/lemmy";
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: inherit;
+
+  margin: -3px;
+  padding: 3px;
+`;
+
+interface VisibleProps {
+  item: PostView | CommentView;
+  className?: string;
+}
+
+export default function Visible({ item, className }: VisibleProps) {
+  const [visible, setVisible] = useState<boolean>();
+  const [presentAlert] = useIonAlert();
+
+  useEffect(() => {
+    isVisibleInCommunity(
+      "comment" in item ? item.comment : item.post,
+      item.community,
+    ).then(setVisible);
+  }, [item]);
+
+  async function isVisibleInCommunity(
+    item: Post | Comment,
+    community: Community,
+  ) {
+    const instance = getItemActorName(community);
+    if (instance === new URL(item.ap_id).hostname) return true;
+
+    const response = await getClient(instance).resolveObject({ q: item.ap_id });
+    return "comment" in response || "post" in response;
+  }
+
+  function presentVisible(e: MouseEvent) {
+    e.stopPropagation();
+
+    if (visible) return;
+
+    presentAlert({
+      header: "Limited visibility",
+      message: "This item is not yet visible in the community it was posted to",
+      buttons: ["OK"],
+    });
+  }
+
+  if (visible !== false) return;
+
+  return (
+    <Container onClick={presentVisible}>
+      <IonIcon icon={warning} color="danger" className={className} />
+    </Container>
+  );
+}

--- a/src/features/labels/Visible.tsx
+++ b/src/features/labels/Visible.tsx
@@ -1,7 +1,7 @@
 import { CommentView, PostView } from "lemmy-js-client";
 import { IonIcon, IonSpinner, useIonAlert } from "@ionic/react";
 import { warning } from "ionicons/icons";
-import { MouseEvent, useEffect } from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import { getItemActorName, getRemoteHandle } from "../../helpers/lemmy";
 import { getClient } from "../../services/lemmy";
@@ -32,6 +32,7 @@ export default function Visible({ item, className }: VisibleProps) {
   const myHandle = useAppSelector(handleSelector);
   const objectByUrl = useAppSelector((state) => state.resolve.objectByUrl);
   const dispatch = useAppDispatch();
+  const [loading, setLoading] = useState(false);
   const [presentAlert] = useIonAlert();
 
   const { ap_id } = "comment" in item ? item.comment : item.post;
@@ -47,10 +48,14 @@ export default function Visible({ item, className }: VisibleProps) {
   })();
 
   useEffect(() => {
-    if (visible === "unknown" && shouldCheck) {
-      dispatch(resolveObject(ap_id, getClient(instance)));
-    }
-  }, [ap_id, instance, shouldCheck, visible, dispatch]);
+    (async () => {
+      if (visible === "unknown" && shouldCheck && !loading) {
+        setLoading(true);
+        await dispatch(resolveObject(ap_id, getClient(instance)));
+        setLoading(false);
+      }
+    })();
+  }, [ap_id, instance, loading, shouldCheck, visible, dispatch]);
 
   function presentVisible(e: MouseEvent) {
     e.stopPropagation();

--- a/src/features/post/detail/Stats.tsx
+++ b/src/features/post/detail/Stats.tsx
@@ -5,6 +5,7 @@ import { PostView } from "lemmy-js-client";
 import Ago from "../../labels/Ago";
 import Vote from "../../labels/Vote";
 import Edited from "../../labels/Edited";
+import Visible from "../../labels/Visible";
 
 const Container = styled.div`
   display: flex;
@@ -33,6 +34,7 @@ export default function Stats({ post }: StatsProps) {
       <IonIcon icon={timeOutline} />
       <Ago date={post.post.published} />
       <Edited item={post} showDate />
+      <Visible item={post} />
     </Container>
   );
 }

--- a/src/features/post/inFeed/PreviewStats.tsx
+++ b/src/features/post/inFeed/PreviewStats.tsx
@@ -5,6 +5,7 @@ import { PostView } from "lemmy-js-client";
 import Ago from "../../labels/Ago";
 import Vote from "../../labels/Vote";
 import { formatNumber } from "../../../helpers/number";
+import Visible from "../../labels/Visible";
 
 const Container = styled.div`
   display: flex;
@@ -24,6 +25,7 @@ export default function PreviewStats({ post }: PreviewStatsProps) {
       {formatNumber(post.counts.comments)}
       <IonIcon icon={timeOutline} />
       <Ago date={post.post.published} />
+      <Visible item={post} />
     </Container>
   );
 }


### PR DESCRIPTION
## Summary

Since Lemmy 0.19 still seems to have outgoing federation issues, I thought it might be helpful if Voyager could check whether my posts or comments have propagated to other instances yet, and display a notification when they haven't.

This PR implements that feature. Any item posted by the currently active user that isn't visible on the home instance of the community it was posted to will have a tiny yellow warning symbol next to it (see screenshots). Only the current user's own content is checked, and only if it wasn't posted to a local community. Tapping the icon will open a dialog explaining its meaning, and gives the user an opportunity to do a manual re-check, since lookups are cached to avoid excessive network traffic.

Currently, the feature is always on and automatically works in the background, but I can add an option in the settings to turn it off completely, or make it manual (via action sheet menu item). I could also add automatic re-checking of non-federated items based on a certain time interval (and make it configurable if desired).

## Screenshots

<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/cd76d7d8-0199-4cd5-84de-97250e7c0d94">

<img width="330" alt="screenshot" src="https://github.com/aeharding/voyager/assets/98132670/d1bd96b7-032e-4a38-9e13-c83753798dc7">

