### PR TITLE
Fix internally routed preview links navigating underneath preview dialog

### DIFF
--- a/src/features/comment/CommentMarkdown.tsx
+++ b/src/features/comment/CommentMarkdown.tsx
@@ -1,19 +1,18 @@
 import { useAppSelector } from "../../store";
 import InAppExternalLink from "../shared/InAppExternalLink";
-import Markdown from "../shared/Markdown";
+import Markdown, { MarkdownProps } from "../shared/Markdown";
 import MarkdownImg from "../shared/MarkdownImg";
 
-interface CommentMarkdownProps {
-  children: string;
-}
-
-export default function CommentMarkdown({ children }: CommentMarkdownProps) {
+export default function CommentMarkdown(
+  props: Omit<MarkdownProps, "components">,
+) {
   const { showCommentImages } = useAppSelector(
     (state) => state.settings.general.comments,
   );
 
   return (
     <Markdown
+      {...props}
       components={{
         img: (props) =>
           !showCommentImages ? (
@@ -32,8 +31,6 @@ export default function CommentMarkdown({ children }: CommentMarkdownProps) {
             />
           ),
       }}
-    >
-      {children}
-    </Markdown>
+    />
   );
 }

--- a/src/features/shared/Markdown.tsx
+++ b/src/features/shared/Markdown.tsx
@@ -4,6 +4,7 @@ import LinkInterceptor from "./markdown/LinkInterceptor";
 import customRemarkGfm from "./markdown/customRemarkGfm";
 import MarkdownImg from "./MarkdownImg";
 import { css } from "@emotion/react";
+import InAppExternalLink from "./InAppExternalLink";
 
 const markdownCss = css`
   @media (max-width: 700px) {
@@ -55,7 +56,15 @@ const TableContainer = styled.div`
   }
 `;
 
-export default function Markdown(props: ReactMarkdownOptions) {
+export interface MarkdownProps
+  extends Omit<ReactMarkdownOptions, "remarkPlugins"> {
+  disableInternalLinkRouting?: boolean;
+}
+
+export default function Markdown({
+  disableInternalLinkRouting,
+  ...props
+}: MarkdownProps) {
   return (
     <ReactMarkdown
       {...props}
@@ -76,7 +85,15 @@ export default function Markdown(props: ReactMarkdownOptions) {
             />
           </TableContainer>
         ),
-        a: (props) => <LinkInterceptor {...props} />,
+        a: disableInternalLinkRouting
+          ? (props) => (
+              <InAppExternalLink
+                {...props}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            )
+          : (props) => <LinkInterceptor {...props} />,
         ...props.components,
       }}
       remarkPlugins={[customRemarkGfm]}

--- a/src/features/shared/markdown/editing/PreviewModal.tsx
+++ b/src/features/shared/markdown/editing/PreviewModal.tsx
@@ -22,11 +22,17 @@ export default function PreviewModal({
   onDismiss,
 }: PreviewModalProps) {
   const content = (() => {
+    // disableInternalLinkRouting to prevent internal links (like @test@example.com)
+    // from taking user away from current page (since user is in a modal)
+    //
+    // TODO future - push internal routes onto the `ion-nav`? might be cool!
     switch (type) {
       case "comment":
-        return <CommentMarkdown>{text}</CommentMarkdown>;
+        return (
+          <CommentMarkdown disableInternalLinkRouting>{text}</CommentMarkdown>
+        );
       case "post":
-        return <Markdown>{text}</Markdown>;
+        return <Markdown disableInternalLinkRouting>{text}</Markdown>;
     }
   })();
 


### PR DESCRIPTION
For example, tapping a user link in the post/comment preview dialog