### PR TITLE
Fix tab switch issue in some scenarios on switching accounts

### DIFF
--- a/src/store.tsx
+++ b/src/store.tsx
@@ -37,7 +37,7 @@ import modSlice from "./features/moderation/modSlice";
 import imageSlice from "./features/post/inFeed/large/imageSlice";
 import feedSortSlice from "./features/feed/sort/feedSortSlice";
 import siteSlice from "./features/auth/siteSlice";
-import { handleOrInstanceSelector } from "./features/auth/authSelectors";
+import { handleSelector } from "./features/auth/authSelectors";
 import pickJoinServerSlice from "./features/auth/login/pickJoinServer/pickJoinServerSlice";
 import joinSlice from "./features/auth/login/join/joinSlice";
 
@@ -75,10 +75,11 @@ export type Dispatchable<T> =
 
 export default store;
 
-let lastActiveHandle: string | undefined = undefined;
+// "uninitialized" so that "uninitialized" -> undefined (logged out) triggers change
+let lastActiveHandle: string | undefined = "uninitialized";
 const activeHandleChange = () => {
   const state = store.getState();
-  const handle = handleOrInstanceSelector(state);
+  const handle = handleSelector(state);
 
   if (handle === lastActiveHandle) return;
 


### PR DESCRIPTION
For example, go to /profile logged out, login, tap posts tab