### PR TITLE
Fix mouse drag swipe actions sometimes getting stuck

### DIFF
--- a/src/features/shared/sliding/BaseSlidingVote.tsx
+++ b/src/features/shared/sliding/BaseSlidingVote.tsx
@@ -14,13 +14,7 @@ import {
   mailUnread,
   share as shareIcon,
 } from "ionicons/icons";
-import React, {
-  MouseEvent,
-  TouchEvent,
-  useCallback,
-  useContext,
-  useMemo,
-} from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import SlidingItem, { ActionList, SlidingItemAction } from "./SlidingItem";
 import {
   CommentReplyView,

--- a/src/features/shared/sliding/SlidingItem.tsx
+++ b/src/features/shared/sliding/SlidingItem.tsx
@@ -1,14 +1,7 @@
 import { ImpactStyle } from "@capacitor/haptics";
 import { IonItemSlidingCustomEvent, ItemSlidingCustomEvent } from "@ionic/core";
 import { IonItemOption, IonItemOptions, IonItemSliding } from "@ionic/react";
-import React, {
-  MouseEvent,
-  TouchEvent,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import useHapticFeedback from "../../../helpers/useHapticFeedback";
 import { bounceAnimation } from "../animations";
 import { useAppSelector } from "../../../store";
@@ -16,6 +9,7 @@ import { OLongSwipeTriggerPointType } from "../../../services/db";
 import ActionContents from "./ActionContents";
 import { styled } from "@linaria/react";
 import { css } from "@linaria/core";
+import useEvent from "../../../helpers/useEvent";
 
 const StyledIonItemSliding = styled(IonItemSliding)`
   overflow: initial; // sticky
@@ -206,32 +200,49 @@ export default function SlidingItem({
     [activeItemIndex],
   );
 
-  const onDragStop = useCallback(
-    async (e: TouchEvent | MouseEvent) => {
-      if (!dragRef.current) return;
-      if (!draggingRef.current) return;
+  const onDragStop = useEvent(
+    useCallback(
+      async (e: TouchEvent | MouseEvent) => {
+        if (!dragRef.current) return;
+        if (!draggingRef.current) return;
 
-      switch (activeItemIndex) {
-        case 1:
-        case 2:
-          endActions[activeItemIndex - 1]?.trigger(e);
-          break;
-        case -1:
-        case -2:
-          startActions[-activeItemIndex - 1]?.trigger(e);
-      }
+        switch (activeItemIndex) {
+          case 1:
+          case 2:
+            endActions[activeItemIndex - 1]?.trigger(e);
+            break;
+          case -1:
+          case -2:
+            startActions[-activeItemIndex - 1]?.trigger(e);
+        }
 
-      dragRef.current.target.closeOpened();
-      draggingRef.current = false;
-    },
-    [endActions, activeItemIndex, startActions],
+        dragRef.current.target.closeOpened();
+        draggingRef.current = false;
+      },
+      [endActions, activeItemIndex, startActions],
+    ),
   );
 
   const onDragStart = useCallback(() => {
     draggingRef.current = true;
 
     setActiveItemIndex(0);
-  }, []);
+
+    const onStop = (e: MouseEvent | TouchEvent) => {
+      cleanup();
+      onDragStop(e);
+    };
+
+    const cleanup = () => {
+      document.removeEventListener("mouseup", onStop);
+      document.removeEventListener("touchend", onStop);
+    };
+
+    document.addEventListener("mouseup", onDragStop);
+    document.addEventListener("touchend", onDragStop);
+
+    return cleanup;
+  }, [onDragStop]);
 
   const startItems = useMemo(() => {
     if (!canSwipeStart) return;
@@ -295,8 +306,6 @@ export default function SlidingItem({
         onIonDrag={onIonDrag}
         onTouchStart={onDragStart}
         onMouseDown={onDragStart}
-        onTouchEnd={onDragStop}
-        onMouseUp={onDragStop}
         className={className}
       >
         {startItems}
@@ -309,7 +318,6 @@ export default function SlidingItem({
   }, [
     onIonDrag,
     onDragStart,
-    onDragStop,
     className,
     startItems,
     endItems,

--- a/src/helpers/useEvent.ts
+++ b/src/helpers/useEvent.ts
@@ -1,0 +1,24 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+// *pokes react*
+// cmon, do something
+// this should be added in react 19, I think?
+// https://github.com/reactjs/rfcs/blob/d85e257502a43c08d17e8ab58efa0880f7f007a5/text/0000-useevent.md#internal-implementation
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function useEvent<T extends (...args: any[]) => any>(
+  handler: T,
+) {
+  const handlerRef = useRef<T | null>(null);
+
+  // In a real implementation, this would run before layout effects
+  useLayoutEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  return useCallback<(...args: Parameters<T>) => ReturnType<T>>((...args) => {
+    // In a real implementation, this would throw if called during render
+    const fn = handlerRef.current!;
+    return fn(...args);
+  }, []);
+}


### PR DESCRIPTION
Essentially when you sipe an item and you cursor is no longer within the item boundaries, the end event will not be detected