### PR TITLE
Ignore Typescript Incremental Cache File

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 .prettierignore
 .vscode/
 
+*.tsbuildinfo
+
 node_modules
 *.md
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ yarn-error.log*
 
 vite.config.ts.timestamp-*
 
+# Typescript Incremental Cache
+*.tsbuildinfo
+
 # fly.io
 fly.toml


### PR DESCRIPTION
When running `tsc --incremental` this file is generated. This can be ignored in git/docker