### PR TITLE
Revamped modlog with moderation reason

### DIFF
--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -14,7 +14,7 @@ import removeComment from "./types/removeComment";
 import removeCommunity from "./types/removeCommunity";
 import removePost from "./types/removePost";
 import transferCommunity from "./types/transferCommunity";
-import { IonItem } from "@ionic/react";
+import { IonIcon, IonItem } from "@ionic/react";
 import { maxWidthCss } from "../../shared/AppContent";
 import Ago from "../../labels/Ago";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
@@ -37,17 +37,51 @@ import {
 } from "lemmy-js-client";
 import { styled } from "@linaria/react";
 
-const Contents = styled.div`
-  font-size: 0.875em;
-  width: 100%;
-
+const Container = styled.div`
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 0;
+  gap: 1rem;
+
+  ${maxWidthCss}
+
+  padding: 0.5rem 0;
+
+  font-size: 0.875em;
+
+  strong {
+    font-weight: 500;
+  }
 `;
 
-const TitleLine = styled.div`
+const StartContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+const Content = styled.div`
+  flex: 1;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  aside {
+    color: var(--ion-color-medium);
+    margin-left: auto;
+
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+`;
+
+const Body = styled.div`
+  color: var(--ion-color-medium);
+  padding: 0.5rem 0;
+`;
+
+const Footer = styled.div`
   display: flex;
   justify-content: space-between;
 
@@ -57,9 +91,6 @@ const TitleLine = styled.div`
 `;
 
 const Title = styled.div``;
-const Message = styled.div`
-  color: var(--ion-color-medium);
-`;
 const Reason = styled.div``;
 
 interface ModLogItemProps {
@@ -67,10 +98,12 @@ interface ModLogItemProps {
 }
 
 export interface LogEntryData {
+  icon: string;
   title: string;
   when: string;
   message?: string;
   reason?: string;
+  expires?: string;
   by?: string;
   link?: string;
 }
@@ -118,7 +151,8 @@ function renderModlogData(item: ModlogItemType): LogEntryData {
 
 export function ModlogItem({ item }: ModLogItemProps) {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
-  const { title, by, when, message, reason, link } = renderModlogData(item);
+  const { icon, title, when, message, reason, expires, link } =
+    renderModlogData(item);
 
   return (
     <IonItem
@@ -126,17 +160,30 @@ export function ModlogItem({ item }: ModLogItemProps) {
       routerLink={link ? buildGeneralBrowseLink(link) : undefined}
       detail={false}
     >
-      <Contents>
-        <TitleLine>
-          <Title>{title}</Title>
-          <aside>
-            {by && <span>{by} · </span>}
-            <Ago date={when} />
-          </aside>
-        </TitleLine>
-        <Message>{message}</Message>
-        {reason && <Reason>Reason: {reason}</Reason>}
-      </Contents>
+      <Container>
+        <StartContent>
+          <IonIcon icon={icon} color="medium" />
+        </StartContent>
+        <Content>
+          <Header>
+            <Title>{title}</Title>
+            <aside>
+              <Ago date={when} />
+            </aside>
+          </Header>
+          <Body>{message}</Body>
+          <Footer>
+            {reason && <Reason>Reason: {reason}</Reason>}
+            <aside>
+              {expires && (
+                <>
+                  expires in <Ago date={expires} />
+                </>
+              )}
+            </aside>
+          </Footer>
+        </Content>
+      </Container>
     </IonItem>
   );
 }

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -18,6 +18,23 @@ import { IonItem } from "@ionic/react";
 import { maxWidthCss } from "../../shared/AppContent";
 import Ago from "../../labels/Ago";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
+import {
+  AdminPurgeCommentView,
+  AdminPurgeCommunityView,
+  AdminPurgePersonView,
+  AdminPurgePostView,
+  ModAddCommunityView,
+  ModAddView,
+  ModBanFromCommunityView,
+  ModBanView,
+  ModFeaturePostView,
+  ModHideCommunityView,
+  ModLockPostView,
+  ModRemoveCommentView,
+  ModRemoveCommunityView,
+  ModRemovePostView,
+  ModTransferCommunityView,
+} from "lemmy-js-client";
 import { styled } from "@linaria/react";
 
 const Contents = styled.div`
@@ -59,35 +76,35 @@ export interface LogEntryData {
 function renderModlogData(item: ModlogItemType): LogEntryData {
   switch (true) {
     case "mod_remove_comment" in item:
-      return removeComment(item);
+      return removeComment(item as ModRemoveCommentView);
     case "mod_remove_post" in item:
-      return removePost(item);
+      return removePost(item as ModRemovePostView);
     case "mod_lock_post" in item:
-      return lockPost(item);
+      return lockPost(item as ModLockPostView);
     case "mod_feature_post" in item:
-      return featurePost(item);
+      return featurePost(item as ModFeaturePostView);
     case "mod_remove_community" in item:
-      return removeCommunity(item);
+      return removeCommunity(item as ModRemoveCommunityView);
     case "mod_ban_from_community" in item:
-      return banFromCommunity(item);
+      return banFromCommunity(item as ModBanFromCommunityView);
     case "mod_ban" in item:
-      return banFromInstance(item);
+      return banFromInstance(item as ModBanView);
     case "mod_add_community" in item:
-      return addCommunity(item);
+      return addCommunity(item as ModAddCommunityView);
     case "mod_transfer_community" in item:
-      return transferCommunity(item);
+      return transferCommunity(item as ModTransferCommunityView);
     case "mod_add" in item:
-      return addInstance(item);
+      return addInstance(item as ModAddView);
     case "admin_purge_person" in item:
-      return purgePerson(item);
+      return purgePerson(item as AdminPurgePersonView);
     case "admin_purge_community" in item:
-      return purgeCommunity(item);
+      return purgeCommunity(item as AdminPurgeCommunityView);
     case "admin_purge_post" in item:
-      return purgePost(item);
+      return purgePost(item as AdminPurgePostView);
     case "admin_purge_comment" in item:
-      return purgeComment(item);
+      return purgeComment(item as AdminPurgeCommentView);
     case "mod_hide_community" in item:
-      return hideCommunity(item);
+      return hideCommunity(item as ModHideCommunityView);
     default:
       // should never happen (type = never)
       //

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -36,7 +36,12 @@ import {
   ModTransferCommunityView,
 } from "lemmy-js-client";
 import ModlogItemMoreActions from "./ModlogItemMoreActions";
-import { getModColor, getModIcon, getModName } from "../useCanModerate";
+import {
+  ModeratorRole,
+  getModColor,
+  getModIcon,
+  getModName,
+} from "../useCanModerate";
 import useIsAdmin from "../useIsAdmin";
 import { timerOutline } from "ionicons/icons";
 import { styled } from "@linaria/react";
@@ -121,7 +126,7 @@ export interface LogEntryData {
   reason?: string;
   expires?: string;
   by?: string;
-  admin?: boolean;
+  role?: ModeratorRole;
   link?: string;
 }
 
@@ -168,8 +173,17 @@ function renderModlogData(item: ModlogItemType): LogEntryData {
 
 export function ModlogItem({ item }: ModLogItemProps) {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
-  const { icon, title, when, by, message, reason, expires, link } =
-    renderModlogData(item);
+  const {
+    icon,
+    title,
+    when,
+    by,
+    role: role_,
+    message,
+    reason,
+    expires,
+    link,
+  } = renderModlogData(item);
 
   const isAdmin = useIsAdmin(
     "admin" in item
@@ -178,8 +192,13 @@ export function ModlogItem({ item }: ModLogItemProps) {
         ? item.moderator
         : undefined,
   );
+
   const role =
-    by && isAdmin ? "admin-local" : "admin" in item ? "admin-remote" : "mod";
+    by && isAdmin
+      ? "admin-local"
+      : "admin" in item
+        ? "admin-remote"
+        : role_ ?? "mod";
 
   return (
     <IonItem
@@ -196,7 +215,7 @@ export function ModlogItem({ item }: ModLogItemProps) {
           <Header>
             <Title>{title}</Title>
             <aside>
-              <ModlogItemMoreActions item={item} />
+              <ModlogItemMoreActions item={item} role={role} />
               <Ago date={when} />
             </aside>
           </Header>

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -18,23 +18,6 @@ import { IonIcon, IonItem } from "@ionic/react";
 import { maxWidthCss } from "../../shared/AppContent";
 import Ago from "../../labels/Ago";
 import { useBuildGeneralBrowseLink } from "../../../helpers/routes";
-import {
-  AdminPurgeCommentView,
-  AdminPurgeCommunityView,
-  AdminPurgePersonView,
-  AdminPurgePostView,
-  ModAddCommunityView,
-  ModAddView,
-  ModBanFromCommunityView,
-  ModBanView,
-  ModFeaturePostView,
-  ModHideCommunityView,
-  ModLockPostView,
-  ModRemoveCommentView,
-  ModRemoveCommunityView,
-  ModRemovePostView,
-  ModTransferCommunityView,
-} from "lemmy-js-client";
 import ModlogItemMoreActions from "./ModlogItemMoreActions";
 import {
   ModeratorRole,
@@ -133,35 +116,35 @@ export interface LogEntryData {
 function renderModlogData(item: ModlogItemType): LogEntryData {
   switch (true) {
     case "mod_remove_comment" in item:
-      return removeComment(item as ModRemoveCommentView);
+      return removeComment(item);
     case "mod_remove_post" in item:
-      return removePost(item as ModRemovePostView);
+      return removePost(item);
     case "mod_lock_post" in item:
-      return lockPost(item as ModLockPostView);
+      return lockPost(item);
     case "mod_feature_post" in item:
-      return featurePost(item as ModFeaturePostView);
+      return featurePost(item);
     case "mod_remove_community" in item:
-      return removeCommunity(item as ModRemoveCommunityView);
+      return removeCommunity(item);
     case "mod_ban_from_community" in item:
-      return banFromCommunity(item as ModBanFromCommunityView);
+      return banFromCommunity(item);
     case "mod_ban" in item:
-      return banFromInstance(item as ModBanView);
+      return banFromInstance(item);
     case "mod_add_community" in item:
-      return addCommunity(item as ModAddCommunityView);
+      return addCommunity(item);
     case "mod_transfer_community" in item:
-      return transferCommunity(item as ModTransferCommunityView);
+      return transferCommunity(item);
     case "mod_add" in item:
-      return addInstance(item as ModAddView);
+      return addInstance(item);
     case "admin_purge_person" in item:
-      return purgePerson(item as AdminPurgePersonView);
+      return purgePerson(item);
     case "admin_purge_community" in item:
-      return purgeCommunity(item as AdminPurgeCommunityView);
+      return purgeCommunity(item);
     case "admin_purge_post" in item:
-      return purgePost(item as AdminPurgePostView);
+      return purgePost(item);
     case "admin_purge_comment" in item:
-      return purgeComment(item as AdminPurgeCommentView);
+      return purgeComment(item);
     case "mod_hide_community" in item:
-      return hideCommunity(item as ModHideCommunityView);
+      return hideCommunity(item);
     default:
       // should never happen (type = never)
       //

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -35,6 +35,7 @@ import {
   ModRemovePostView,
   ModTransferCommunityView,
 } from "lemmy-js-client";
+import ModlogItemMoreActions from "./ModlogItemMoreActions";
 import { styled } from "@linaria/react";
 
 const Container = styled.div`
@@ -157,6 +158,7 @@ export function ModlogItem({ item }: ModLogItemProps) {
   return (
     <IonItem
       className={maxWidthCss}
+      href={undefined}
       routerLink={link ? buildGeneralBrowseLink(link) : undefined}
       detail={false}
     >
@@ -168,6 +170,7 @@ export function ModlogItem({ item }: ModLogItemProps) {
           <Header>
             <Title>{title}</Title>
             <aside>
+              <ModlogItemMoreActions item={item} />
               <Ago date={when} />
             </aside>
           </Header>

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -60,6 +60,7 @@ const Title = styled.div``;
 const Message = styled.div`
   color: var(--ion-color-medium);
 `;
+const Reason = styled.div``;
 
 interface ModLogItemProps {
   item: ModlogItemType;
@@ -69,6 +70,7 @@ export interface LogEntryData {
   title: string;
   when: string;
   message?: string;
+  reason?: string;
   by?: string;
   link?: string;
 }
@@ -116,7 +118,7 @@ function renderModlogData(item: ModlogItemType): LogEntryData {
 
 export function ModlogItem({ item }: ModLogItemProps) {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
-  const { title, by, when, message, link } = renderModlogData(item);
+  const { title, by, when, message, reason, link } = renderModlogData(item);
 
   return (
     <IonItem
@@ -133,6 +135,7 @@ export function ModlogItem({ item }: ModLogItemProps) {
           </aside>
         </TitleLine>
         <Message>{message}</Message>
+        {reason && <Reason>Reason: {reason}</Reason>}
       </Contents>
     </IonItem>
   );

--- a/src/features/moderation/logs/ModlogItem.tsx
+++ b/src/features/moderation/logs/ModlogItem.tsx
@@ -36,6 +36,9 @@ import {
   ModTransferCommunityView,
 } from "lemmy-js-client";
 import ModlogItemMoreActions from "./ModlogItemMoreActions";
+import { getModColor, getModIcon, getModName } from "../useCanModerate";
+import useIsAdmin from "../useIsAdmin";
+import { timerOutline } from "ionicons/icons";
 import { styled } from "@linaria/react";
 
 const Container = styled.div`
@@ -85,14 +88,26 @@ const Body = styled.div`
 const Footer = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 
   aside {
     color: var(--ion-color-medium);
+    display: flex;
+    align-items: center;
+    gap: 6px;
   }
 `;
 
 const Title = styled.div``;
 const Reason = styled.div``;
+const By = styled.div<{ color: string }>`
+  display: flex;
+  justify-content: right;
+  align-items: center;
+  gap: 6px;
+  padding: 0.5rem 0;
+  color: ${({ color }) => `var(--ion-color-${color}-shade)`};
+`;
 
 interface ModLogItemProps {
   item: ModlogItemType;
@@ -106,6 +121,7 @@ export interface LogEntryData {
   reason?: string;
   expires?: string;
   by?: string;
+  admin?: boolean;
   link?: string;
 }
 
@@ -152,8 +168,18 @@ function renderModlogData(item: ModlogItemType): LogEntryData {
 
 export function ModlogItem({ item }: ModLogItemProps) {
   const buildGeneralBrowseLink = useBuildGeneralBrowseLink();
-  const { icon, title, when, message, reason, expires, link } =
+  const { icon, title, when, by, message, reason, expires, link } =
     renderModlogData(item);
+
+  const isAdmin = useIsAdmin(
+    "admin" in item
+      ? item.admin
+      : "moderator" in item
+        ? item.moderator
+        : undefined,
+  );
+  const role =
+    by && isAdmin ? "admin-local" : "admin" in item ? "admin-remote" : "mod";
 
   return (
     <IonItem
@@ -175,15 +201,17 @@ export function ModlogItem({ item }: ModLogItemProps) {
             </aside>
           </Header>
           <Body>{message}</Body>
+          {reason && <Reason>Reason: {reason}</Reason>}
           <Footer>
-            {reason && <Reason>Reason: {reason}</Reason>}
-            <aside>
-              {expires && (
-                <>
-                  expires in <Ago date={expires} />
-                </>
-              )}
-            </aside>
+            <By color={getModColor(role)}>
+              <IonIcon icon={getModIcon(role)} />
+              {by ? by : getModName(role)}
+            </By>
+            {expires && (
+              <aside>
+                <IonIcon icon={timerOutline} /> <Ago date={expires} />
+              </aside>
+            )}
           </Footer>
         </Content>
       </Container>

--- a/src/features/moderation/logs/ModlogItemMoreActions.tsx
+++ b/src/features/moderation/logs/ModlogItemMoreActions.tsx
@@ -1,4 +1,5 @@
 import { styled } from "@linaria/react";
+import { compact } from "lodash";
 import { IonIcon, useIonActionSheet } from "@ionic/react";
 import {
   ellipsisHorizontal,
@@ -8,7 +9,6 @@ import {
 import { ModlogItemType } from "../../../routes/pages/shared/ModlogPage";
 import { getHandle } from "../../../helpers/lemmy";
 import useAppNavigation from "../../../helpers/useAppNavigation";
-import { notEmpty } from "../../../helpers/array";
 import { ModeratorRole, getModIcon } from "../useCanModerate";
 
 const EllipsisIcon = styled(IonIcon)`
@@ -43,7 +43,7 @@ export default function ModlogItemMoreActions({
   function presentMoreActions() {
     presentActionSheet({
       cssClass: "left-align-buttons",
-      buttons: [
+      buttons: compact([
         person
           ? {
               text: getHandle(person),
@@ -76,7 +76,7 @@ export default function ModlogItemMoreActions({
           text: "Cancel",
           role: "cancel",
         },
-      ].filter(notEmpty),
+      ]),
     });
   }
 

--- a/src/features/moderation/logs/ModlogItemMoreActions.tsx
+++ b/src/features/moderation/logs/ModlogItemMoreActions.tsx
@@ -9,8 +9,7 @@ import { ModlogItemType } from "../../../routes/pages/shared/ModlogPage";
 import { getHandle } from "../../../helpers/lemmy";
 import useAppNavigation from "../../../helpers/useAppNavigation";
 import { notEmpty } from "../../../helpers/array";
-import useIsAdmin from "../useIsAdmin";
-import { getModIcon } from "../useCanModerate";
+import { ModeratorRole, getModIcon } from "../useCanModerate";
 
 const EllipsisIcon = styled(IonIcon)`
   font-size: 1.2rem;
@@ -18,9 +17,13 @@ const EllipsisIcon = styled(IonIcon)`
 
 interface ModlogItemMoreActions {
   item: ModlogItemType;
+  role: ModeratorRole;
 }
 
-export default function ModlogItemMoreActions({ item }: ModlogItemMoreActions) {
+export default function ModlogItemMoreActions({
+  item,
+  role,
+}: ModlogItemMoreActions) {
   const { navigateToCommunity, navigateToUser } = useAppNavigation();
   const [presentActionSheet] = useIonActionSheet();
 
@@ -35,14 +38,6 @@ export default function ModlogItemMoreActions({ item }: ModlogItemMoreActions) {
   const moderator = (() => {
     if ("moderator" in item) return item.moderator;
     if ("admin" in item) return item.admin;
-  })();
-
-  const isAdmin = useIsAdmin(moderator);
-
-  const role = (() => {
-    if (moderator && isAdmin) return "admin-local";
-    if ("admin" in item) return "admin-remote";
-    return "mod";
   })();
 
   function presentMoreActions() {

--- a/src/features/moderation/logs/ModlogItemMoreActions.tsx
+++ b/src/features/moderation/logs/ModlogItemMoreActions.tsx
@@ -1,0 +1,87 @@
+import { styled } from "@linaria/react";
+import { IonIcon, useIonActionSheet } from "@ionic/react";
+import {
+  ellipsisHorizontal,
+  peopleOutline,
+  personOutline,
+  shieldCheckmarkOutline,
+} from "ionicons/icons";
+import { ModlogItemType } from "../../../routes/pages/shared/ModlogPage";
+import { getHandle } from "../../../helpers/lemmy";
+import useAppNavigation from "../../../helpers/useAppNavigation";
+import { notEmpty } from "../../../helpers/array";
+
+const EllipsisIcon = styled(IonIcon)`
+  font-size: 1.2rem;
+`;
+
+interface ModlogItemMoreActions {
+  item: ModlogItemType;
+}
+
+export default function ModlogItemMoreActions({ item }: ModlogItemMoreActions) {
+  const { navigateToCommunity, navigateToUser } = useAppNavigation();
+  const [presentActionSheet] = useIonActionSheet();
+
+  const community = "community" in item ? item.community : undefined;
+
+  const person = (() => {
+    if ("commenter" in item) return item.commenter;
+    if ("banned_person" in item) return item.banned_person;
+    if ("modded_person" in item) return item.modded_person;
+  })();
+
+  const moderator = (() => {
+    if ("moderator" in item) return item.moderator;
+    if ("admin" in item) return item.admin;
+  })();
+
+  function presentMoreActions() {
+    presentActionSheet({
+      cssClass: "left-align-buttons",
+      buttons: [
+        person
+          ? {
+              text: getHandle(person),
+              icon: personOutline,
+              handler: () => {
+                navigateToUser(person);
+              },
+            }
+          : undefined,
+        community
+          ? {
+              text: getHandle(community),
+              icon: peopleOutline,
+              handler: () => {
+                navigateToCommunity(community);
+              },
+            }
+          : undefined,
+        moderator
+          ? {
+              text: getHandle(moderator),
+              icon: shieldCheckmarkOutline,
+              handler: () => {
+                navigateToUser(moderator);
+              },
+            }
+          : undefined,
+        {
+          text: "Cancel",
+          role: "cancel",
+        },
+      ].filter(notEmpty),
+    });
+  }
+
+  return (
+    <EllipsisIcon
+      icon={ellipsisHorizontal}
+      onClick={(e) => {
+        e.stopPropagation();
+        presentMoreActions();
+      }}
+    />
+  );
+}

--- a/src/features/moderation/logs/ModlogItemMoreActions.tsx
+++ b/src/features/moderation/logs/ModlogItemMoreActions.tsx
@@ -4,12 +4,13 @@ import {
   ellipsisHorizontal,
   peopleOutline,
   personOutline,
-  shieldCheckmarkOutline,
 } from "ionicons/icons";
 import { ModlogItemType } from "../../../routes/pages/shared/ModlogPage";
 import { getHandle } from "../../../helpers/lemmy";
 import useAppNavigation from "../../../helpers/useAppNavigation";
 import { notEmpty } from "../../../helpers/array";
+import useIsAdmin from "../useIsAdmin";
+import { getModIcon } from "../useCanModerate";
 
 const EllipsisIcon = styled(IonIcon)`
   font-size: 1.2rem;
@@ -34,6 +35,14 @@ export default function ModlogItemMoreActions({ item }: ModlogItemMoreActions) {
   const moderator = (() => {
     if ("moderator" in item) return item.moderator;
     if ("admin" in item) return item.admin;
+  })();
+
+  const isAdmin = useIsAdmin(moderator);
+
+  const role = (() => {
+    if (moderator && isAdmin) return "admin-local";
+    if ("admin" in item) return "admin-remote";
+    return "mod";
   })();
 
   function presentMoreActions() {
@@ -61,7 +70,8 @@ export default function ModlogItemMoreActions({ item }: ModlogItemMoreActions) {
         moderator
           ? {
               text: getHandle(moderator),
-              icon: shieldCheckmarkOutline,
+              icon: getModIcon(role),
+              cssClass: role,
               handler: () => {
                 navigateToUser(moderator);
               },

--- a/src/features/moderation/logs/types/addCommunity.ts
+++ b/src/features/moderation/logs/types/addCommunity.ts
@@ -1,7 +1,7 @@
 import { ModAddCommunityView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
 import { shieldCheckmark, shieldHalf } from "ionicons/icons";
 
@@ -10,6 +10,7 @@ export default function addCommunity(item: ModAddCommunityView): LogEntryData {
     icon: item.mod_add_community.removed ? shieldCheckmark : shieldHalf,
     title: `${item.mod_add_community.removed ? "Added" : "Removed"} Mod`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
+    role: getAdminRole(item.moderator),
     message: `${getHandle(item.modded_person)} ${
       item.mod_add_community.removed ? "to" : "from"
     } ${getHandle(item.community)}`,

--- a/src/features/moderation/logs/types/addCommunity.ts
+++ b/src/features/moderation/logs/types/addCommunity.ts
@@ -3,12 +3,16 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
+import { shieldCheckmark, shieldHalf } from "ionicons/icons";
 
 export default function addCommunity(item: ModAddCommunityView): LogEntryData {
   return {
+    icon: item.mod_add_community.removed ? shieldCheckmark : shieldHalf,
     title: `${item.mod_add_community.removed ? "Added" : "Removed"} Mod`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
-    message: getHandle(item.modded_person),
+    message: `${getHandle(item.modded_person)} ${
+      item.mod_add_community.removed ? "to" : "from"
+    } ${getHandle(item.community)}`,
     link: buildUserLink(item.modded_person),
     ...buildBaseData(item.mod_add_community),
   };

--- a/src/features/moderation/logs/types/addInstance.ts
+++ b/src/features/moderation/logs/types/addInstance.ts
@@ -1,7 +1,7 @@
 import { ModAddView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
 import { shieldCheckmark, shieldHalf } from "ionicons/icons";
 
@@ -10,6 +10,7 @@ export default function addInstance(item: ModAddView): LogEntryData {
     icon: item.mod_add.removed ? shieldCheckmark : shieldHalf,
     title: `${item.mod_add.removed ? "Added" : "Removed"} Admin`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
+    role: getAdminRole(item.moderator),
     message: getHandle(item.modded_person),
     link: buildUserLink(item.modded_person),
     ...buildBaseData(item.mod_add),

--- a/src/features/moderation/logs/types/addInstance.ts
+++ b/src/features/moderation/logs/types/addInstance.ts
@@ -3,9 +3,11 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
+import { shieldCheckmark, shieldHalf } from "ionicons/icons";
 
 export default function addInstance(item: ModAddView): LogEntryData {
   return {
+    icon: item.mod_add.removed ? shieldCheckmark : shieldHalf,
     title: `${item.mod_add.removed ? "Added" : "Removed"} Admin`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: getHandle(item.modded_person),

--- a/src/features/moderation/logs/types/banFromCommunity.ts
+++ b/src/features/moderation/logs/types/banFromCommunity.ts
@@ -3,12 +3,16 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
+import { personAdd, personRemove } from "ionicons/icons";
 
 export default function banFromCommunity(
   item: ModBanFromCommunityView,
 ): LogEntryData {
   return {
-    title: `${item.mod_ban_from_community.banned ? "Banned" : "Unbanned"} User`,
+    icon: item.mod_ban_from_community.banned ? personRemove : personAdd,
+    title: `${
+      item.mod_ban_from_community.banned ? "Banned" : "Unbanned"
+    } User from Community`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: `${getHandle(item.banned_person)} from ${getHandle(
       item.community,

--- a/src/features/moderation/logs/types/banFromInstance.ts
+++ b/src/features/moderation/logs/types/banFromInstance.ts
@@ -1,6 +1,6 @@
 import { ModBanView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
-import { getHandle } from "../../../../helpers/lemmy";
+import { getHandle, getItemActorName } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
 import { ban, refresh } from "ionicons/icons";
@@ -10,7 +10,9 @@ export default function banFromInstance(item: ModBanView): LogEntryData {
     icon: item.mod_ban.banned ? ban : refresh,
     title: `${item.mod_ban.banned ? "Banned" : "Unbanned"} User`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
-    message: getHandle(item.banned_person),
+    message:
+      getHandle(item.banned_person) +
+      (item.moderator ? ` from ${getItemActorName(item.moderator)}` : ""),
     link: buildUserLink(item.banned_person),
     ...buildBaseData(item.mod_ban),
   };

--- a/src/features/moderation/logs/types/banFromInstance.ts
+++ b/src/features/moderation/logs/types/banFromInstance.ts
@@ -1,7 +1,7 @@
 import { ModBanView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle, getItemActorName } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
 import { ban, refresh } from "ionicons/icons";
 
@@ -10,6 +10,7 @@ export default function banFromInstance(item: ModBanView): LogEntryData {
     icon: item.mod_ban.banned ? ban : refresh,
     title: `${item.mod_ban.banned ? "Banned" : "Unbanned"} User`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
+    role: getAdminRole(item.moderator),
     message:
       getHandle(item.banned_person) +
       (item.moderator ? ` from ${getItemActorName(item.moderator)}` : ""),

--- a/src/features/moderation/logs/types/banFromInstance.ts
+++ b/src/features/moderation/logs/types/banFromInstance.ts
@@ -6,7 +6,7 @@ import { buildUserLink } from "../../../../helpers/appLinkBuilder";
 
 export default function banFromInstance(item: ModBanView): LogEntryData {
   return {
-    title: `${item.mod_ban.banned ? "Banned" : "Unbanned"} User [instance]`,
+    title: `${item.mod_ban.banned ? "Banned" : "Unbanned"} User`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: getHandle(item.banned_person),
     link: buildUserLink(item.banned_person),

--- a/src/features/moderation/logs/types/banFromInstance.ts
+++ b/src/features/moderation/logs/types/banFromInstance.ts
@@ -3,9 +3,11 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildUserLink } from "../../../../helpers/appLinkBuilder";
+import { ban, refresh } from "ionicons/icons";
 
 export default function banFromInstance(item: ModBanView): LogEntryData {
   return {
+    icon: item.mod_ban.banned ? ban : refresh,
     title: `${item.mod_ban.banned ? "Banned" : "Unbanned"} User`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: getHandle(item.banned_person),

--- a/src/features/moderation/logs/types/featurePost.ts
+++ b/src/features/moderation/logs/types/featurePost.ts
@@ -3,9 +3,11 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData, buildPostMessage } from "./shared";
 import { buildPostLink } from "../../../../helpers/appLinkBuilder";
+import { megaphone, volumeOff } from "ionicons/icons";
 
 export default function featurePost(item: ModFeaturePostView): LogEntryData {
   return {
+    icon: item.mod_feature_post.featured ? megaphone : volumeOff,
     title: `${item.mod_feature_post.featured ? "Stickied" : "Unstickied"} Post`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: buildPostMessage(item.post),

--- a/src/features/moderation/logs/types/hideCommunity.ts
+++ b/src/features/moderation/logs/types/hideCommunity.ts
@@ -1,7 +1,7 @@
 import { ModHideCommunityView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { buildCommunityLink } from "../../../../helpers/appLinkBuilder";
 import { eye, eyeOff } from "ionicons/icons";
 
@@ -12,6 +12,7 @@ export default function hideCommunity(
     icon: item.mod_hide_community.hidden ? eyeOff : eye,
     title: `${item.mod_hide_community.hidden ? "Hid" : "Unhid"} Community`,
     by: item.admin ? getHandle(item.admin) : undefined,
+    role: getAdminRole(item.admin),
     message: getHandle(item.community),
     link: buildCommunityLink(item.community),
     ...buildBaseData(item.mod_hide_community),

--- a/src/features/moderation/logs/types/hideCommunity.ts
+++ b/src/features/moderation/logs/types/hideCommunity.ts
@@ -3,11 +3,13 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildCommunityLink } from "../../../../helpers/appLinkBuilder";
+import { eye, eyeOff } from "ionicons/icons";
 
 export default function hideCommunity(
   item: ModHideCommunityView,
 ): LogEntryData {
   return {
+    icon: item.mod_hide_community.hidden ? eyeOff : eye,
     title: `${item.mod_hide_community.hidden ? "Hid" : "Unhid"} Community`,
     by: item.admin ? getHandle(item.admin) : undefined,
     message: getHandle(item.community),

--- a/src/features/moderation/logs/types/lockPost.ts
+++ b/src/features/moderation/logs/types/lockPost.ts
@@ -3,9 +3,11 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData, buildPostMessage } from "./shared";
 import { buildPostLink } from "../../../../helpers/appLinkBuilder";
+import { lockClosed, lockOpen } from "ionicons/icons";
 
 export default function lockPost(item: ModLockPostView): LogEntryData {
   return {
+    icon: item.mod_lock_post.locked ? lockClosed : lockOpen,
     title: `${item.mod_lock_post.locked ? "Locked" : "Unlocked"} Post`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: buildPostMessage(item.post),

--- a/src/features/moderation/logs/types/purgeComment.ts
+++ b/src/features/moderation/logs/types/purgeComment.ts
@@ -2,11 +2,13 @@ import { AdminPurgeCommentView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
+import { trashBin } from "ionicons/icons";
 
 export default function purgeComment(
   item: AdminPurgeCommentView,
 ): LogEntryData {
   return {
+    icon: trashBin,
     title: "Purged Comment",
     by: item.admin ? getHandle(item.admin) : undefined,
     ...buildBaseData(item.admin_purge_comment),

--- a/src/features/moderation/logs/types/purgeComment.ts
+++ b/src/features/moderation/logs/types/purgeComment.ts
@@ -1,7 +1,7 @@
 import { AdminPurgeCommentView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { trashBin } from "ionicons/icons";
 
 export default function purgeComment(
@@ -11,6 +11,7 @@ export default function purgeComment(
     icon: trashBin,
     title: "Purged Comment",
     by: item.admin ? getHandle(item.admin) : undefined,
+    role: getAdminRole(item.admin),
     ...buildBaseData(item.admin_purge_comment),
   };
 }

--- a/src/features/moderation/logs/types/purgeCommunity.ts
+++ b/src/features/moderation/logs/types/purgeCommunity.ts
@@ -2,11 +2,13 @@ import { AdminPurgeCommunityView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
+import { trashBin } from "ionicons/icons";
 
 export default function purgeCommunity(
   item: AdminPurgeCommunityView,
 ): LogEntryData {
   return {
+    icon: trashBin,
     title: "Purged Community",
     by: item.admin ? getHandle(item.admin) : undefined,
     ...buildBaseData(item.admin_purge_community),

--- a/src/features/moderation/logs/types/purgeCommunity.ts
+++ b/src/features/moderation/logs/types/purgeCommunity.ts
@@ -1,7 +1,7 @@
 import { AdminPurgeCommunityView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { trashBin } from "ionicons/icons";
 
 export default function purgeCommunity(
@@ -11,6 +11,7 @@ export default function purgeCommunity(
     icon: trashBin,
     title: "Purged Community",
     by: item.admin ? getHandle(item.admin) : undefined,
+    role: getAdminRole(item.admin),
     ...buildBaseData(item.admin_purge_community),
   };
 }

--- a/src/features/moderation/logs/types/purgePerson.ts
+++ b/src/features/moderation/logs/types/purgePerson.ts
@@ -1,7 +1,7 @@
 import { AdminPurgePersonView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { trashBin } from "ionicons/icons";
 
 export default function purgePerson(item: AdminPurgePersonView): LogEntryData {
@@ -9,6 +9,7 @@ export default function purgePerson(item: AdminPurgePersonView): LogEntryData {
     icon: trashBin,
     title: "Purged User",
     by: item.admin ? getHandle(item.admin) : undefined,
+    role: getAdminRole(item.admin),
     ...buildBaseData(item.admin_purge_person),
   };
 }

--- a/src/features/moderation/logs/types/purgePerson.ts
+++ b/src/features/moderation/logs/types/purgePerson.ts
@@ -2,9 +2,11 @@ import { AdminPurgePersonView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
+import { trashBin } from "ionicons/icons";
 
 export default function purgePerson(item: AdminPurgePersonView): LogEntryData {
   return {
+    icon: trashBin,
     title: "Purged User",
     by: item.admin ? getHandle(item.admin) : undefined,
     ...buildBaseData(item.admin_purge_person),

--- a/src/features/moderation/logs/types/purgePost.ts
+++ b/src/features/moderation/logs/types/purgePost.ts
@@ -2,9 +2,11 @@ import { AdminPurgePostView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
+import { trashBin } from "ionicons/icons";
 
 export default function purgePost(item: AdminPurgePostView): LogEntryData {
   return {
+    icon: trashBin,
     title: "Purged Post",
     by: item.admin ? getHandle(item.admin) : undefined,
     ...buildBaseData(item.admin_purge_post),

--- a/src/features/moderation/logs/types/purgePost.ts
+++ b/src/features/moderation/logs/types/purgePost.ts
@@ -1,7 +1,7 @@
 import { AdminPurgePostView } from "lemmy-js-client";
 import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
-import { buildBaseData } from "./shared";
+import { buildBaseData, getAdminRole } from "./shared";
 import { trashBin } from "ionicons/icons";
 
 export default function purgePost(item: AdminPurgePostView): LogEntryData {
@@ -9,6 +9,7 @@ export default function purgePost(item: AdminPurgePostView): LogEntryData {
     icon: trashBin,
     title: "Purged Post",
     by: item.admin ? getHandle(item.admin) : undefined,
+    role: getAdminRole(item.admin),
     ...buildBaseData(item.admin_purge_post),
   };
 }

--- a/src/features/moderation/logs/types/removeComment.ts
+++ b/src/features/moderation/logs/types/removeComment.ts
@@ -3,11 +3,13 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData, buildCommentMessage } from "./shared";
 import { buildCommentLink } from "../../../../helpers/appLinkBuilder";
+import { arrowUndoCircle, trash } from "ionicons/icons";
 
 export default function removeComment(
   item: ModRemoveCommentView,
 ): LogEntryData {
   return {
+    icon: item.mod_remove_comment.removed ? trash : arrowUndoCircle,
     title: `${
       item.mod_remove_comment.removed ? "Removed" : "Restored"
     } Comment`,

--- a/src/features/moderation/logs/types/removeCommunity.ts
+++ b/src/features/moderation/logs/types/removeCommunity.ts
@@ -3,11 +3,13 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildCommunityLink } from "../../../../helpers/appLinkBuilder";
+import { arrowUndoCircle, trash } from "ionicons/icons";
 
 export default function removeCommunity(
   item: ModRemoveCommunityView,
 ): LogEntryData {
   return {
+    icon: item.mod_remove_community.removed ? trash : arrowUndoCircle,
     title: `${
       item.mod_remove_community.removed ? "Removed" : "Restored"
     } Community`,

--- a/src/features/moderation/logs/types/removePost.ts
+++ b/src/features/moderation/logs/types/removePost.ts
@@ -3,9 +3,11 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData, buildPostMessage } from "./shared";
 import { buildPostLink } from "../../../../helpers/appLinkBuilder";
+import { arrowUndoCircle, trash } from "ionicons/icons";
 
 export default function removePost(item: ModRemovePostView): LogEntryData {
   return {
+    icon: item.mod_remove_post.removed ? trash : arrowUndoCircle,
     title: `${item.mod_remove_post.removed ? "Removed" : "Restored"} Post`,
     by: item.moderator ? getHandle(item.moderator) : undefined,
     message: buildPostMessage(item.post),

--- a/src/features/moderation/logs/types/shared.ts
+++ b/src/features/moderation/logs/types/shared.ts
@@ -3,10 +3,11 @@ import { Comment, Post } from "lemmy-js-client";
 interface ModItem {
   when_: string;
   reason?: string;
+  expires?: string;
 }
 
-export function buildBaseData({ when_, reason }: ModItem) {
-  return { when: when_, reason };
+export function buildBaseData({ when_, reason, expires }: ModItem) {
+  return { when: when_, reason, expires };
 }
 
 export function buildPostMessage(post: Post): string {

--- a/src/features/moderation/logs/types/shared.ts
+++ b/src/features/moderation/logs/types/shared.ts
@@ -1,4 +1,5 @@
-import { Comment, Post } from "lemmy-js-client";
+import { Comment, Person, Post } from "lemmy-js-client";
+import { ModeratorRole } from "../../useCanModerate";
 
 interface ModItem {
   when_: string;
@@ -16,4 +17,8 @@ export function buildPostMessage(post: Post): string {
 
 export function buildCommentMessage(comment: Comment): string {
   return `‘${comment.content}’`;
+}
+
+export function getAdminRole(person: Person | undefined): ModeratorRole {
+  return person && person.local ? "admin-local" : "admin-remote";
 }

--- a/src/features/moderation/logs/types/transferCommunity.ts
+++ b/src/features/moderation/logs/types/transferCommunity.ts
@@ -3,14 +3,16 @@ import { LogEntryData } from "../ModlogItem";
 import { getHandle } from "../../../../helpers/lemmy";
 import { buildBaseData } from "./shared";
 import { buildCommunityLink } from "../../../../helpers/appLinkBuilder";
+import { swapHorizontal } from "ionicons/icons";
 
 export default function transferCommunity(
   item: ModTransferCommunityView,
 ): LogEntryData {
   return {
+    icon: swapHorizontal,
     title: "Transferred Community",
     by: item.moderator ? getHandle(item.moderator) : undefined,
-    message: getHandle(item.community),
+    message: `${getHandle(item.community)} to ${getHandle(item.modded_person)}`,
     link: buildCommunityLink(item.community),
     ...buildBaseData(item.mod_transfer_community),
   };

--- a/src/features/moderation/useIsAdmin.tsx
+++ b/src/features/moderation/useIsAdmin.tsx
@@ -1,6 +1,12 @@
+import { Person } from "lemmy-js-client";
 import { useAppSelector } from "../../store";
-import { isAdminSelector } from "../auth/siteSlice";
 
-export default function useIsAdmin() {
-  return useAppSelector(isAdminSelector);
+export default function useIsAdmin(person?: Person) {
+  return useAppSelector((state) => {
+    return state.site.response?.admins?.some(
+      (admin) =>
+        admin.person.id ===
+        (person?.id ?? state.site.response?.my_user?.local_user_view.person.id),
+    );
+  });
 }

--- a/src/features/moderation/useIsAdmin.tsx
+++ b/src/features/moderation/useIsAdmin.tsx
@@ -1,12 +1,14 @@
 import { Person } from "lemmy-js-client";
 import { useAppSelector } from "../../store";
+import { isAdminSelector } from "../auth/siteSlice";
 
 export default function useIsAdmin(person?: Person) {
-  return useAppSelector((state) => {
-    return state.site.response?.admins?.some(
-      (admin) =>
-        admin.person.id ===
-        (person?.id ?? state.site.response?.my_user?.local_user_view.person.id),
-    );
-  });
+  useAppSelector(
+    !person
+      ? isAdminSelector
+      : (state) =>
+          state.site.response?.admins?.some(
+            (admin) => admin.person.id === person.id,
+          ),
+  );
 }

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -1,11 +1,5 @@
 import { pullAt } from "lodash";
 
-export function notEmpty<TValue>(
-  value: TValue | null | undefined,
-): value is TValue {
-  return value !== null && value !== undefined;
-}
-
 // https://stackoverflow.com/a/60132060/1319878
 export const arrayOfAll =
   <T>() =>

--- a/src/helpers/array.ts
+++ b/src/helpers/array.ts
@@ -1,5 +1,11 @@
 import { pullAt } from "lodash";
 
+export function notEmpty<TValue>(
+  value: TValue | null | undefined,
+): value is TValue {
+  return value !== null && value !== undefined;
+}
+
 // https://stackoverflow.com/a/60132060/1319878
 export const arrayOfAll =
   <T>() =>

--- a/src/helpers/useAppNavigation.ts
+++ b/src/helpers/useAppNavigation.ts
@@ -8,6 +8,7 @@ import {
 } from "lemmy-js-client";
 import { getHandle } from "./lemmy";
 import { useBuildGeneralBrowseLink } from "./routes";
+import { buildCommunityLink } from "./appLinkBuilder";
 import { useCallback } from "react";
 import useAppToast from "./useAppToast";
 import { checkmark } from "ionicons/icons";
@@ -50,9 +51,9 @@ export default function useAppNavigation() {
     (community: CommunityView | Community) => {
       pushRouteIfNeeded(
         buildGeneralBrowseLink(
-          `/c/${getHandle(
+          buildCommunityLink(
             "community" in community ? community.community : community,
-          )}`,
+          ),
         ),
       );
     },

--- a/src/helpers/useAppNavigation.ts
+++ b/src/helpers/useAppNavigation.ts
@@ -1,5 +1,6 @@
 import {
   CommentView,
+  Community,
   CommunityView,
   Person,
   PersonView,
@@ -46,9 +47,13 @@ export default function useAppNavigation() {
   );
 
   const navigateToCommunity = useCallback(
-    (community: CommunityView) => {
+    (community: CommunityView | Community) => {
       pushRouteIfNeeded(
-        buildGeneralBrowseLink(`/c/${getHandle(community.community)}`),
+        buildGeneralBrowseLink(
+          `/c/${getHandle(
+            "community" in community ? community.community : community,
+          )}`,
+        ),
       );
     },
     [buildGeneralBrowseLink, pushRouteIfNeeded],


### PR DESCRIPTION
By request, I rebased my old branch for #1046 to hopefully work with the recent code changes.

Had to restore a couple of functions that were removed or changed (`helpers/array.ts#notEmpty()` and `useIsAdmin()` with optional argument). Only tested briefly but seems to work fine.