### PR TITLE
Improve support for testing (http, custom ports, env variables)

### DIFF
--- a/src/features/auth/authSelectors.ts
+++ b/src/features/auth/authSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { RootState } from "../../store";
-import { buildBaseLemmyUrl, getClient } from "../../services/lemmy";
+import { getClient } from "../../services/lemmy";
 import { parseLemmyJWT } from "../../helpers/lemmy";
 
 export const activeAccount = createSelector(
@@ -88,6 +88,3 @@ export const loggedInAccountsSelector = createSelector(
   [(state: RootState) => state.auth.accountData?.accounts],
   (accounts) => accounts?.filter(({ jwt }) => jwt),
 );
-
-export const connectedInstanceUrlSelector = (state: RootState) =>
-  buildBaseLemmyUrl(state.auth.connectedInstance);

--- a/src/features/auth/authSelectors.ts
+++ b/src/features/auth/authSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { RootState } from "../../store";
-import { getClient } from "../../services/lemmy";
+import { buildBaseLemmyUrl, getClient } from "../../services/lemmy";
 import { parseLemmyJWT } from "../../helpers/lemmy";
 
 export const activeAccount = createSelector(
@@ -88,3 +88,6 @@ export const loggedInAccountsSelector = createSelector(
   [(state: RootState) => state.auth.accountData?.accounts],
   (accounts) => accounts?.filter(({ jwt }) => jwt),
 );
+
+export const connectedInstanceUrlSelector = (state: RootState) =>
+  buildBaseLemmyUrl(state.auth.connectedInstance);

--- a/src/features/auth/login/login/Login.tsx
+++ b/src/features/auth/login/login/Login.tsx
@@ -26,7 +26,7 @@ import Totp from "./Totp";
 import { DynamicDismissableModalContext } from "../../../shared/DynamicDismissableModal";
 import InAppExternalLink from "../../../shared/InAppExternalLink";
 import { HelperText } from "../../../settings/shared/formatting";
-import { getImageSrc } from "../../../../services/lemmy";
+import { buildBaseLemmyUrl, getImageSrc } from "../../../../services/lemmy";
 import { loginSuccess } from "../../../../helpers/toastMessages";
 import lemmyLogo from "../lemmyLogo.svg";
 import { styled } from "@linaria/react";
@@ -162,7 +162,7 @@ export default function Login({ url, siteIcon }: LoginProps) {
         <div className="ion-padding">
           You are logging in to{" "}
           <InAppExternalLink
-            href={`https://${url}`}
+            href={buildBaseLemmyUrl(url)}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/features/comment/CommentLinks.tsx
+++ b/src/features/comment/CommentLinks.tsx
@@ -10,6 +10,7 @@ import { Text } from "mdast";
 import { uniqBy } from "lodash";
 import { isValidUrl } from "../../helpers/url";
 import spoiler from "@aeharding/remark-lemmy-spoiler";
+import { connectedInstanceUrlSelector } from "../auth/authSelectors";
 
 const Container = styled.div`
   display: flex;
@@ -34,6 +35,7 @@ export default function CommentLinks({ markdown }: CommentLinksProps) {
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance,
   );
+  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
 
   const links = useMemo(() => {
     // Initialize a unified processor with the remark-parse parser
@@ -56,7 +58,7 @@ export default function CommentLinks({ markdown }: CommentLinksProps) {
         links.push({
           type: node.type,
           // normalize relative links
-          url: new URL(node.url, `https://${connectedInstance}`).href,
+          url: new URL(node.url, connectedInstanceUrl).href,
           text:
             "children" in node ? (node.children[0] as Text)?.value : undefined,
         });
@@ -72,7 +74,7 @@ export default function CommentLinks({ markdown }: CommentLinksProps) {
     links = links.slice(0, 4);
 
     return links;
-  }, [markdown, showCommentImages, connectedInstance]);
+  }, [connectedInstance, markdown, showCommentImages, connectedInstanceUrl]);
 
   if (!links.length) return;
 

--- a/src/features/comment/CommentLinks.tsx
+++ b/src/features/comment/CommentLinks.tsx
@@ -10,7 +10,7 @@ import { Text } from "mdast";
 import { uniqBy } from "lodash";
 import { isValidUrl } from "../../helpers/url";
 import spoiler from "@aeharding/remark-lemmy-spoiler";
-import { connectedInstanceUrlSelector } from "../auth/authSelectors";
+import { buildBaseLemmyUrl } from "../../services/lemmy";
 
 const Container = styled.div`
   display: flex;
@@ -35,7 +35,7 @@ export default function CommentLinks({ markdown }: CommentLinksProps) {
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance,
   );
-  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
+  const connectedInstanceUrl = buildBaseLemmyUrl(connectedInstance);
 
   const links = useMemo(() => {
     // Initialize a unified processor with the remark-parse parser

--- a/src/features/feed/SpecialFeedMoreActions.tsx
+++ b/src/features/feed/SpecialFeedMoreActions.tsx
@@ -12,6 +12,7 @@ import {
   useSetPostAppearance,
 } from "../post/appearance/PostAppearanceProvider";
 import { getShareIcon } from "../../helpers/device";
+import { buildBaseLemmyUrl } from "../../services/lemmy";
 
 interface SpecialFeedMoreActionsProps {
   type: ListingType;
@@ -40,10 +41,10 @@ export default function SpecialFeedMoreActions({
           text: "Share",
           icon: getShareIcon(),
           handler: () => {
-            const url = urlSelector(store.getState());
+            const url = buildBaseLemmyUrl(urlSelector(store.getState()));
 
             Share.share({
-              url: `https://${url}?dataType=Post&listingType=${type}`,
+              url: `${url}?dataType=Post&listingType=${type}`,
             });
           },
         },

--- a/src/features/shared/markdown/LinkInterceptor.tsx
+++ b/src/features/shared/markdown/LinkInterceptor.tsx
@@ -3,7 +3,7 @@ import InAppExternalLink from "../InAppExternalLink";
 import useLemmyUrlHandler from "../useLemmyUrlHandler";
 import { useAppSelector } from "../../../store";
 import { styled } from "@linaria/react";
-import { connectedInstanceUrlSelector } from "../../auth/authSelectors";
+import { buildBaseLemmyUrl } from "../../../services/lemmy";
 
 const LinkInterceptor = styled(LinkInterceptorUnstyled)`
   -webkit-touch-callout: default;
@@ -24,7 +24,9 @@ function LinkInterceptorUnstyled({
   forceResolveObject,
   ...props
 }: LinkInterceptorUnstyledProps) {
-  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
+  const connectedInstanceUrl = useAppSelector((state) =>
+    buildBaseLemmyUrl(state.auth.connectedInstance),
+  );
   const { redirectToLemmyObjectIfNeeded } = useLemmyUrlHandler();
 
   const absoluteHref = useMemo(() => {

--- a/src/features/shared/markdown/LinkInterceptor.tsx
+++ b/src/features/shared/markdown/LinkInterceptor.tsx
@@ -3,6 +3,7 @@ import InAppExternalLink from "../InAppExternalLink";
 import useLemmyUrlHandler from "../useLemmyUrlHandler";
 import { useAppSelector } from "../../../store";
 import { styled } from "@linaria/react";
+import { connectedInstanceUrlSelector } from "../../auth/authSelectors";
 
 const LinkInterceptor = styled(LinkInterceptorUnstyled)`
   -webkit-touch-callout: default;
@@ -23,20 +24,18 @@ function LinkInterceptorUnstyled({
   forceResolveObject,
   ...props
 }: LinkInterceptorUnstyledProps) {
-  const connectedInstance = useAppSelector(
-    (state) => state.auth.connectedInstance,
-  );
+  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
   const { redirectToLemmyObjectIfNeeded } = useLemmyUrlHandler();
 
   const absoluteHref = useMemo(() => {
     if (!props.href) return;
 
     try {
-      return new URL(props.href, `https://${connectedInstance}`).href;
+      return new URL(props.href, connectedInstanceUrl).href;
     } catch (_) {
       return;
     }
-  }, [connectedInstance, props.href]);
+  }, [connectedInstanceUrl, props.href]);
 
   const onClick = useCallback(
     async (e: React.MouseEvent<HTMLAnchorElement>) => {

--- a/src/features/shared/useLemmyUrlHandler.ts
+++ b/src/features/shared/useLemmyUrlHandler.ts
@@ -8,6 +8,7 @@ import { MouseEvent } from "react";
 import useAppToast from "../../helpers/useAppToast";
 import { isLemmyError } from "../../helpers/lemmyErrors";
 import { useOptimizedIonRouter } from "../../helpers/useOptimizedIonRouter";
+import { connectedInstanceUrlSelector } from "../auth/authSelectors";
 
 export const POST_PATH = /^\/post\/(\d+)$/;
 
@@ -43,6 +44,7 @@ export default function useLemmyUrlHandler() {
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance,
   );
+  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
   const objectByUrl = useAppSelector((state) => state.resolve.objectByUrl);
   const {
     navigateToComment,
@@ -162,12 +164,12 @@ export default function useLemmyUrlHandler() {
   const getUrl = useCallback(
     (link: string) => {
       try {
-        return new URL(link, `https://${connectedInstance}`);
+        return new URL(link, connectedInstanceUrl);
       } catch (error) {
         console.error("Error parsing url", error);
       }
     },
-    [connectedInstance],
+    [connectedInstanceUrl],
   );
 
   const determineObjectTypeFromUrl = useCallback(

--- a/src/features/shared/useLemmyUrlHandler.ts
+++ b/src/features/shared/useLemmyUrlHandler.ts
@@ -8,7 +8,7 @@ import { MouseEvent } from "react";
 import useAppToast from "../../helpers/useAppToast";
 import { isLemmyError } from "../../helpers/lemmyErrors";
 import { useOptimizedIonRouter } from "../../helpers/useOptimizedIonRouter";
-import { connectedInstanceUrlSelector } from "../auth/authSelectors";
+import { buildBaseLemmyUrl } from "../../services/lemmy";
 
 export const POST_PATH = /^\/post\/(\d+)$/;
 
@@ -44,7 +44,7 @@ export default function useLemmyUrlHandler() {
   const connectedInstance = useAppSelector(
     (state) => state.auth.connectedInstance,
   );
-  const connectedInstanceUrl = useAppSelector(connectedInstanceUrlSelector);
+  const connectedInstanceUrl = buildBaseLemmyUrl(connectedInstance);
   const objectByUrl = useAppSelector((state) => state.resolve.objectByUrl);
   const {
     navigateToComment,

--- a/src/routes/common/ActorRedirect.tsx
+++ b/src/routes/common/ActorRedirect.tsx
@@ -33,7 +33,7 @@ function ActorRedirectEnabled({ children }: ActorRedirectProps) {
   const [first, second, _wrongActor, ...urlEnd] = location.pathname.split("/");
 
   // no need to redirect if url doesn't have actor
-  if (!_wrongActor || !_wrongActor.includes(".")) return page;
+  if (!_wrongActor || !isPotentialActor(_wrongActor)) return page;
 
   return (
     <Redirect
@@ -41,4 +41,13 @@ function ActorRedirectEnabled({ children }: ActorRedirectProps) {
       push={false}
     />
   );
+}
+
+function isPotentialActor(host: string) {
+  if (host.includes(".")) return true;
+  if (host.includes(":")) return true;
+
+  if (host.startsWith("localhost")) return true;
+
+  return false;
 }

--- a/src/services/app.ts
+++ b/src/services/app.ts
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { isNative } from "../helpers/device";
 import { isEqual } from "lodash";
 
-const DEFAULT_LEMMY_SERVERS = ["lemmy.world"];
+const DEFAULT_LEMMY_SERVERS = getCustomDefaultServers() ?? ["lemmy.world"];
 
 let _customServers = DEFAULT_LEMMY_SERVERS;
 
@@ -52,4 +52,12 @@ export default function ConfigProvider({ children }: ConfigProviderProps) {
   }, []);
 
   if (configLoaded) return children;
+}
+
+function getCustomDefaultServers() {
+  const serversList = import.meta.env.VITE_CUSTOM_LEMMY_SERVERS;
+
+  if (!serversList) return;
+
+  return serversList.split(",");
 }

--- a/src/services/lemmy.ts
+++ b/src/services/lemmy.ts
@@ -3,12 +3,16 @@ import { reduceFileSize } from "../helpers/imageCompress";
 import { isNative, supportsWebp } from "../helpers/device";
 import nativeFetch from "./nativeFetch";
 
-function buildBaseUrl(url: string): string {
+export function buildBaseLemmyUrl(url: string): string {
+  if (import.meta.env.VITE_FORCE_LEMMY_INSECURE) {
+    return `http://${url}`;
+  }
+
   return `https://${url}`;
 }
 
 export function getClient(url: string, jwt?: string): LemmyHttp {
-  return new LemmyHttp(buildBaseUrl(url), {
+  return new LemmyHttp(buildBaseLemmyUrl(url), {
     fetchFunction: isNative() ? nativeFetch : fetch.bind(globalThis),
     headers: jwt
       ? {


### PR DESCRIPTION
Resolves #1576

Now you can set the following (testing purposes only!):

- `VITE_FORCE_LEMMY_INSECURE=1` to force all lemmy instance connections to http instead of https.
- `VITE_CUSTOM_LEMMY_SERVERS=localhost:3001,localhost:3002` a comma separated list of default lemmy servers. If _config is found it will be preferred.