### PR TITLE
Feat: Persist 'Share as Image' options

### DIFF
--- a/src/features/share/asImage/ShareAsImagePreferences.ts
+++ b/src/features/share/asImage/ShareAsImagePreferences.ts
@@ -63,10 +63,10 @@ const { reducer, actions } = createSlice({
       state.comment.allParentComments =
         comment?.allParentComments ?? state.comment.allParentComments;
 
-      db.setSetting("share_as_image_preferences", {
-        post: { ...state.post },
-        comment: { ...state.comment },
-      });
+      db.setSetting(
+        "share_as_image_preferences",
+        JSON.parse(JSON.stringify(state)),
+      );
     },
   },
 });

--- a/src/features/share/asImage/ShareAsImagePreferences.ts
+++ b/src/features/share/asImage/ShareAsImagePreferences.ts
@@ -1,0 +1,105 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { db } from "../../../services/db";
+import {
+  AppDispatch,
+  RootState,
+  useAppDispatch,
+  useAppSelector,
+} from "../../../store";
+import { useCallback, useEffect } from "react";
+import { DeepPartial } from "../../../helpers/deepPartial";
+
+export interface ShareAsImagePreferences {
+  post: {
+    hideCommunity: boolean;
+    hideUsername: boolean;
+    watermark: boolean;
+  };
+  comment: {
+    includePostDetails: boolean;
+    includePostText: boolean;
+    hideUsernames: boolean;
+    watermark: boolean;
+    allParentComments: boolean;
+  };
+}
+
+const initialState: ShareAsImagePreferences = {
+  post: {
+    hideCommunity: false,
+    hideUsername: false,
+    watermark: false,
+  },
+  comment: {
+    includePostText: false,
+    includePostDetails: false,
+    hideUsernames: false,
+    watermark: false,
+    allParentComments: false,
+  },
+};
+
+const { reducer, actions } = createSlice({
+  name: "shareAsImagePreferences",
+  initialState,
+  reducers: {
+    setShareAsImagePreferences: (
+      state,
+      action: PayloadAction<DeepPartial<ShareAsImagePreferences>>,
+    ) => {
+      const { post, comment } = action.payload;
+      state.post.hideCommunity =
+        post?.hideCommunity ?? state.post.hideCommunity;
+      state.post.hideUsername = post?.hideUsername ?? state.post.hideUsername;
+      state.post.watermark = post?.watermark ?? state.post.watermark;
+
+      state.comment.includePostText =
+        comment?.includePostText ?? state.comment.includePostText;
+      state.comment.includePostDetails =
+        comment?.includePostDetails ?? state.comment.includePostDetails;
+      state.comment.hideUsernames =
+        comment?.hideUsernames ?? state.comment.hideUsernames;
+      state.comment.watermark = comment?.watermark ?? state.comment.watermark;
+      state.comment.allParentComments =
+        comment?.allParentComments ?? state.comment.allParentComments;
+
+      db.setSetting("share_as_image_preferences", {
+        post: { ...state.post },
+        comment: { ...state.comment },
+      });
+    },
+  },
+});
+
+export default reducer;
+
+export const useShareAsImagePreferences = () => {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    // Load settings from DB on mount
+    dispatch(async (dispatchImpl: AppDispatch) => {
+      const share_as_image_preferences = await db.getSetting(
+        "share_as_image_preferences",
+      );
+      dispatchImpl(
+        actions.setShareAsImagePreferences(
+          share_as_image_preferences ?? initialState,
+        ),
+      );
+    });
+  }, [dispatch]);
+
+  const shareAsImagePreferences = useAppSelector(
+    (state) => state.shareAsImagePreferences,
+  );
+
+  const setShareAsImagePreferences = useCallback(
+    (payload: DeepPartial<ShareAsImagePreferences>) => {
+      dispatch(actions.setShareAsImagePreferences(payload));
+    },
+    [dispatch],
+  );
+
+  return { shareAsImagePreferences, setShareAsImagePreferences };
+};

--- a/src/helpers/deepPartial.ts
+++ b/src/helpers/deepPartial.ts
@@ -1,0 +1,7 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[P] extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : DeepPartial<T[P]>;
+};

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -5,6 +5,7 @@ import { zipObject } from "lodash";
 import { ALL_POST_SORTS } from "../features/feed/PostSort";
 import { COMMENT_SORTS } from "../features/comment/CommentSort";
 import { StringArrayToIdentityObject } from "../helpers/typescript";
+import { ShareAsImagePreferences } from "../features/share/asImage/ShareAsImagePreferences";
 
 export interface IPostMetadata {
   post_id: number;
@@ -362,6 +363,7 @@ export type SettingValueTypes = {
   show_collapsed_comment: boolean;
   quick_switch_dark_mode: boolean;
   subscribed_icon: ShowSubscribedIcon;
+  share_as_image_preferences: ShareAsImagePreferences;
 };
 
 export interface ISettingItem<T extends keyof SettingValueTypes> {

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -49,6 +49,7 @@ import redgifsSlice from "./features/media/external/redgifs/redgifsSlice";
 import uploadImageSlice from "./features/shared/markdown/editing/uploadImageSlice";
 import postAppearanceSlice from "./features/post/appearance/appearanceSlice";
 import thumbnailSlice from "./features/post/link/thumbnail/thumbnailSlice";
+import ShareAsImagePreferencesSlice from "./features/share/asImage/ShareAsImagePreferences";
 
 const store = configureStore({
   reducer: {
@@ -78,6 +79,7 @@ const store = configureStore({
     uploadImage: uploadImageSlice,
     postAppearance: postAppearanceSlice,
     thumbnail: thumbnailSlice,
+    shareAsImagePreferences: ShareAsImagePreferencesSlice,
   },
 });
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
- initial implementation
- use JSON.parse
