### PR TITLE
Update e2e action to use a better testing setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,17 +1,9 @@
 name: Run e2e tests
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: workflow_dispatch
 jobs:
   playwright:
     name: Run Playwright tests
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.46.0-jammy
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable
@@ -23,5 +15,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build project
         run: pnpm build
-      - name: Run tests
-        run: env HOME=/root pnpm test:e2e
+        env:
+          VITE_FORCE_LEMMY_INSECURE: 1
+          VITE_CUSTOM_LEMMY_SERVERS: localhost:8536
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: |
+          docker compose -f e2e/ci/docker-compose.yml up -d
+          sleep 10
+          pnpm run test:e2e

--- a/e2e/ci/docker-compose.yml
+++ b/e2e/ci/docker-compose.yml
@@ -1,0 +1,46 @@
+# Based on the nginx config made available by Lemmy developers.
+# https://github.com/LemmyNet/lemmy
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "50m"
+    max-file: "4"
+
+services:
+  proxy:
+    image: nginx:1-alpine
+    ports:
+      - "8536:8536"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro,Z
+    restart: unless-stopped
+    logging: *default-logging
+
+  lemmy:
+    image: dessalines/lemmy:0.19.5
+    platform: linux/x86_64
+    hostname: lemmy
+    restart: unless-stopped
+    environment:
+      - RUST_LOG="warn,lemmy_server=debug,lemmy_api=debug,lemmy_api_common=debug,lemmy_api_crud=debug,lemmy_apub=debug,lemmy_db_schema=debug,lemmy_db_views=debug,lemmy_db_views_actor=debug,lemmy_db_views_moderator=debug,lemmy_routes=debug,lemmy_utils=debug,lemmy_websocket=debug"
+      - RUST_BACKTRACE=full
+    volumes:
+      - ./lemmy.hjson:/config/config.hjson:Z
+    depends_on:
+      - postgres
+    logging: *default-logging
+
+  postgres:
+    image: postgres
+    hostname: postgres
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=lemmy
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=lemmy
+    volumes:
+      - ./volumes/postgres:/var/lib/postgresql/data:Z
+    restart: unless-stopped
+    logging: *default-logging

--- a/e2e/ci/lemmy.hjson
+++ b/e2e/ci/lemmy.hjson
@@ -1,0 +1,20 @@
+{
+  setup: {
+    admin_username: "voyager"
+    admin_password: "voyagerapp"
+    site_name: "voyager"
+  }
+
+  database: {
+    host: postgres
+  }
+
+  hostname: "localhost"
+  bind: "0.0.0.0"
+  port: 8536
+
+  pictrs: {
+    url: "http://pictrs:8080/"
+    image_mode: None
+  }
+}

--- a/e2e/ci/nginx.conf
+++ b/e2e/ci/nginx.conf
@@ -1,0 +1,34 @@
+# Based on the nginx config made available by Lemmy developers.
+# https://github.com/LemmyNet/lemmy
+
+worker_processes 1;
+events {
+    worker_connections 1024;
+}
+http {
+    upstream lemmy {
+        # this needs to map to the lemmy (server) docker service hostname
+        server "lemmy:8536";
+    }
+
+    server {
+        listen 8536;
+        # change if needed, this is facing the public web
+        server_name localhost;
+        server_tokens off;
+
+        # backend
+        location ~ ^/(api|pictrs|feeds|nodeinfo|version|.well-known) {
+            proxy_pass "http://lemmy";
+            # proxy common stuff
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            # Send actual client IP upstream
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
Some things I want to highlight or would like opinions/thoughts on.
- The e2e action, as of this commit, will not run on `push` and `pull_request` triggers. It will have to be manually triggered.
- The idea is to ensure that the tests are somewhat stable before adding back these removed triggers. In the meantime, there will be failed runs of the action but they will become increasingly infrequent with time.
- PRs will be fairly frequent for the next few weeks and tests might undergo several changes (and refactors) before they become stable. This will probably involve breaking from this repo's convention of squash merging PRs but I will try to avoid any superfluous commits.
- If you feel there are user stories that should take priority, please let me know.