### PR TITLE
Override lemmy server URL when 'VITE__TEST_MODE' is set

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,7 @@ jobs:
         env:
           VITE_FORCE_LEMMY_INSECURE: 1
           VITE_CUSTOM_LEMMY_SERVERS: localhost:8536
+          VITE__TEST_MODE: 1
       - name: Install Playwright dependencies
         run: npx playwright install --with-deps
       - name: Run Playwright tests

--- a/src/features/auth/authSelectors.ts
+++ b/src/features/auth/authSelectors.ts
@@ -49,8 +49,11 @@ export const instanceSelector = createSelector([handleSelector], (handle) => {
   return getInstanceFromHandle(handle);
 });
 
-export const urlSelector = (state: RootState) =>
-  instanceSelector(state) ?? state.auth.connectedInstance;
+export const urlSelector = (state: RootState) => {
+  if (import.meta.env.VITE__TEST_MODE) return state.auth.connectedInstance;
+
+  return instanceSelector(state) ?? state.auth.connectedInstance;
+};
 
 export const clientSelector = createSelector(
   [urlSelector, jwtSelector],

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -142,6 +142,10 @@ export const authSlice = createSlice({
     },
 
     updateConnectedInstance(state, action: PayloadAction<string>) {
+      if (import.meta.env.VITE__TEST_MODE) {
+        state.connectedInstance = getDefaultServer();
+        return;
+      }
       state.connectedInstance = action.payload;
     },
   },

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -16,6 +16,7 @@ import { getInstanceFromHandle, instanceSelector } from "./authSelectors";
 import { receivedSite, resetSite } from "./siteSlice";
 import { Register } from "lemmy-js-client";
 import { setDefaultFeed } from "../settings/settingsSlice";
+import { getDefaultServer } from "../../services/app";
 
 const MULTI_ACCOUNT_STORAGE_NAME = "credentials";
 


### PR DESCRIPTION
After the user logs in, `state.auth.currentInstance` changes from `<hostname>:<PORT>` to `<hostname>` [1]. Setting `VITE__TEST_MODE=1` will override this behaviour with a couple of small changes and no side-effects. Using this var name because similar overrides might be needed elsewhere in the future and this should cover most (or all) of them.

Also updated the build step in e2e action.


[1]: [Lemmy sets the `iss` claim to hostname](https://github.com/LemmyNet/lemmy/blob/63a686d390e441216718a3d64408336409890791/crates/api_common/src/claims.rs#L48) when creating JWTs. `authSlice.addJwt` updates `state.auth.currentInstance` with the value of this claim.