### PR TITLE
Update CommunitySelectorModal API query to use global limit

### DIFF
--- a/src/features/shared/selectorModals/CommunitySelectorModal.tsx
+++ b/src/features/shared/selectorModals/CommunitySelectorModal.tsx
@@ -2,6 +2,7 @@ import { CommunityView } from "lemmy-js-client";
 
 import { getHandle } from "#/helpers/lemmy";
 import useClient from "#/helpers/useClient";
+import { LIMIT } from "#/services/lemmy";
 
 import GenericSelectorModal from "./GenericSelectorModal";
 
@@ -19,6 +20,7 @@ export default function CommunitySelectorModal(
       q: query,
       type_: "Communities",
       sort: "TopAll",
+      limit: LIMIT,
     });
 
     return result.communities;


### PR DESCRIPTION
Change to correct behavior documented @ https://github.com/aeharding/voyager/issues/1652

I chose to use the existing LIMIT constant (50) instead of 20 - but can correct this to exactly match lemmy-ui, if that's preferred.