### PR TITLE
Feat: Collapse downvoted comments by default when setting (default off) is set

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,13 +9,13 @@ overrides:
 
 patchedDependencies:
   '@capacitor/android':
-    hash: dca4cd0644bfe52632f4d81f97b9ddc5ddcd67caae25988a52f9014428029ab6
+    hash: a7fuehdtpweg2aifrflzmu363i
     path: patches/@capacitor__android.patch
   '@capacitor/haptics':
-    hash: daa342ffd526f01bd99bc1242d366ebc0d25fc5ec30939e5be0046b277a0d4fc
+    hash: isktf3ewuigcwl72katxy46idi
     path: patches/@capacitor__haptics@6.0.1.patch
   '@capacitor/keyboard':
-    hash: a9b910edbb5059e863b0b44c347168d2bf0b0a421868be03f71586ecd0859f11
+    hash: 2ihcxo2fu55l7b6g5u7feswwlm
     path: patches/@capacitor__keyboard@6.0.2.patch
 
 importers:
@@ -30,7 +30,7 @@ importers:
         version: 6.0.0(@capacitor/core@7.0.1)
       '@capacitor/android':
         specifier: ^7.0.1
-        version: 7.0.1(patch_hash=dca4cd0644bfe52632f4d81f97b9ddc5ddcd67caae25988a52f9014428029ab6)(@capacitor/core@7.0.1)
+        version: 7.0.1(patch_hash=a7fuehdtpweg2aifrflzmu363i)(@capacitor/core@7.0.1)
       '@capacitor/app':
         specifier: ^7.0.0
         version: 7.0.0(@capacitor/core@7.0.1)
@@ -42,13 +42,13 @@ importers:
         version: 7.0.0(@capacitor/core@7.0.1)
       '@capacitor/haptics':
         specifier: ^7.0.0
-        version: 7.0.0(patch_hash=daa342ffd526f01bd99bc1242d366ebc0d25fc5ec30939e5be0046b277a0d4fc)(@capacitor/core@7.0.1)
+        version: 7.0.0(patch_hash=isktf3ewuigcwl72katxy46idi)(@capacitor/core@7.0.1)
       '@capacitor/ios':
         specifier: ^7.0.1
         version: 7.0.1(@capacitor/core@7.0.1)
       '@capacitor/keyboard':
         specifier: ^7.0.0
-        version: 7.0.0(patch_hash=a9b910edbb5059e863b0b44c347168d2bf0b0a421868be03f71586ecd0859f11)(@capacitor/core@7.0.1)
+        version: 7.0.0(patch_hash=2ihcxo2fu55l7b6g5u7feswwlm)(@capacitor/core@7.0.1)
       '@capacitor/network':
         specifier: ^7.0.0
         version: 7.0.0(@capacitor/core@7.0.1)
@@ -7334,7 +7334,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 7.0.1
 
-  '@capacitor/android@7.0.1(patch_hash=dca4cd0644bfe52632f4d81f97b9ddc5ddcd67caae25988a52f9014428029ab6)(@capacitor/core@7.0.1)':
+  '@capacitor/android@7.0.1(patch_hash=a7fuehdtpweg2aifrflzmu363i)(@capacitor/core@7.0.1)':
     dependencies:
       '@capacitor/core': 7.0.1
 
@@ -7372,7 +7372,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 7.0.1
 
-  '@capacitor/haptics@7.0.0(patch_hash=daa342ffd526f01bd99bc1242d366ebc0d25fc5ec30939e5be0046b277a0d4fc)(@capacitor/core@7.0.1)':
+  '@capacitor/haptics@7.0.0(patch_hash=isktf3ewuigcwl72katxy46idi)(@capacitor/core@7.0.1)':
     dependencies:
       '@capacitor/core': 7.0.1
 
@@ -7380,7 +7380,7 @@ snapshots:
     dependencies:
       '@capacitor/core': 7.0.1
 
-  '@capacitor/keyboard@7.0.0(patch_hash=a9b910edbb5059e863b0b44c347168d2bf0b0a421868be03f71586ecd0859f11)(@capacitor/core@7.0.1)':
+  '@capacitor/keyboard@7.0.0(patch_hash=2ihcxo2fu55l7b6g5u7feswwlm)(@capacitor/core@7.0.1)':
     dependencies:
       '@capacitor/core': 7.0.1
 

--- a/src/features/comment/inTree/CommentTree.tsx
+++ b/src/features/comment/inTree/CommentTree.tsx
@@ -32,14 +32,27 @@ export default function CommentTree({
   baseDepth,
 }: CommentTreeProps) {
   const dispatch = useAppDispatch();
+  const commentId = comment.comment_view.comment.id;
+  const hasUserCollapsed = useAppSelector((state) =>
+    Object.hasOwn(state.comment.commentCollapsedById, commentId),
+  );
   const collapsed = useAppSelector(
-    (state) =>
-      state.comment.commentCollapsedById[comment.comment_view.comment.id],
+    (state) => state.comment.commentCollapsedById[commentId],
   );
   const tapToCollapse = useAppSelector(
     (state) => state.settings.general.comments.tapToCollapse,
   );
   const { activePageRef } = useContext(AppContext);
+
+  const downvotedCollapsedByDefault = useAppSelector(
+    (state) => state.settings.general.comments.downvotedCollapsedByDefault,
+  );
+
+  const isDownvoted =
+    comment.comment_view.counts.upvotes < comment.comment_view.counts.downvotes;
+  const shouldBeCollapsed = hasUserCollapsed
+    ? collapsed
+    : downvotedCollapsedByDefault && isDownvoted;
 
   // Comment context chains don't show missing for parents
   const showMissing = (() => {
@@ -68,7 +81,7 @@ export default function CommentTree({
         depth={comment.absoluteDepth - baseDepth}
         absoluteDepth={comment.absoluteDepth}
         key={comment.comment_view.comment.id}
-        collapsed={collapsed || fullyCollapsed}
+        collapsed={shouldBeCollapsed || fullyCollapsed}
         comment={comment}
       />
     );
@@ -101,7 +114,7 @@ export default function CommentTree({
 
           scrollCommentIntoViewIfNeeded(e.target, activePageRef);
         }}
-        collapsed={collapsed}
+        collapsed={shouldBeCollapsed}
         fullyCollapsed={!!fullyCollapsed}
         rootIndex={rootIndex}
       />
@@ -111,7 +124,7 @@ export default function CommentTree({
         key={comment.comment_view.comment.id}
         highlightedCommentId={highlightedCommentId}
         comment={comment}
-        fullyCollapsed={collapsed || fullyCollapsed}
+        fullyCollapsed={shouldBeCollapsed || fullyCollapsed}
         rootIndex={rootIndex}
         baseDepth={baseDepth}
       />
@@ -126,7 +139,7 @@ export default function CommentTree({
         depth={comment.absoluteDepth - baseDepth}
         absoluteDepth={comment.absoluteDepth}
         missing={comment.missing}
-        collapsed={collapsed || fullyCollapsed}
+        collapsed={shouldBeCollapsed || fullyCollapsed}
       />,
     );
   }

--- a/src/features/settings/general/comments/Comments.tsx
+++ b/src/features/settings/general/comments/Comments.tsx
@@ -3,6 +3,7 @@ import { IonLabel, IonList } from "@ionic/react";
 import { ListHeader } from "#/features/settings/shared/formatting";
 
 import CollapsedByDefault from "./CollapsedByDefault";
+import DownvotedCollapsedByDefault from "./DownvotedCollapsedByDefault";
 import DefaultSort from "./DefaultSort";
 import HighlightNewAccount from "./HighlightNewAccount";
 import JumpButtonPosition from "./JumpButtonPosition";
@@ -30,6 +31,7 @@ export default function Comments() {
         <TouchFriendlyLinks />
         <ShowCommentImages />
         <ShowCollapsed />
+        <DownvotedCollapsedByDefault />
       </IonList>
     </>
   );

--- a/src/features/settings/general/comments/DownvotedCollapsedByDefault.tsx
+++ b/src/features/settings/general/comments/DownvotedCollapsedByDefault.tsx
@@ -1,0 +1,25 @@
+import { IonItem, IonToggle } from "@ionic/react";
+
+import { useAppDispatch, useAppSelector } from "#/store";
+
+import { setDownvotedCollapsedByDefault } from "../../settingsSlice";
+
+export default function DownvotedCollapsedByDefault() {
+  const dispatch = useAppDispatch();
+  const downvotedCollapsedByDefault = useAppSelector(
+    (state) => state.settings.general.comments.downvotedCollapsedByDefault,
+  );
+
+  return (
+    <IonItem>
+      <IonToggle
+        checked={downvotedCollapsedByDefault}
+        onIonChange={(e) =>
+          dispatch(setDownvotedCollapsedByDefault(e.detail.checked))
+        }
+      >
+        Collapse Downvoted Comments
+      </IonToggle>
+    </IonItem>
+  );
+}

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -121,6 +121,7 @@ export interface SettingsState {
   };
   general: {
     comments: {
+      downvotedCollapsedByDefault: boolean;
       collapseCommentThreads: CommentThreadCollapse;
       tapToCollapse: TapToCollapseType;
       sort: CommentDefaultSort;
@@ -232,6 +233,7 @@ const baseState: SettingsState = {
       jumpButtonPosition: OJumpButtonPositionType.RightBottom,
       rememberCommunitySort: false,
       showCollapsed: false,
+      downvotedCollapsedByDefault: false,
       showCommentImages: true,
       showJumpButton: false,
       sort: OCommentDefaultSort.Hot,
@@ -490,6 +492,10 @@ export const settingsSlice = createSlice({
     setShowCollapsedComment(state, action: PayloadAction<boolean>) {
       state.general.comments.showCollapsed = action.payload;
       db.setSetting("show_collapsed_comment", action.payload);
+    },
+    setDownvotedCollapsedByDefault(state, action: PayloadAction<boolean>) {
+      state.general.comments.downvotedCollapsedByDefault = action.payload;
+      db.setSetting("downvoted_collapsed_by_default", action.payload);
     },
     setShowCommentImages(state, action: PayloadAction<boolean>) {
       state.general.comments.showCommentImages = action.payload;
@@ -820,6 +826,7 @@ export const {
   setRememberCommunityPostSort,
   setRememberPostAppearance,
   setShowCollapsedComment,
+  setDownvotedCollapsedByDefault,
   setShowCommentImages,
   setShowCommunityIcons,
   setShowControlsOnOpen,
@@ -910,6 +917,7 @@ function hydrateStateWithGlobalSettings(
         sort: settings.default_comment_sort,
         tapToCollapse: settings.tap_to_collapse,
         touchFriendlyLinks: settings.touch_friendly_links,
+        downvotedCollapsedByDefault: settings.downvoted_collapsed_by_default,
       },
       defaultShare: settings.default_share,
       enableHapticFeedback: settings.enable_haptic_feedback,

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -376,6 +376,7 @@ export interface GlobalSettingValueTypes {
   remember_community_post_sort: boolean;
   remember_post_appearance_type: boolean;
   show_collapsed_comment: boolean;
+  downvoted_collapsed_by_default: boolean;
   show_comment_images: boolean;
   show_community_icons: boolean;
   show_controls_on_open: boolean;
@@ -455,6 +456,7 @@ export const ALL_GLOBAL_SETTINGS = arrayOfAll<keyof GlobalSettingValueTypes>()([
   "remember_community_post_sort",
   "remember_post_appearance_type",
   "show_collapsed_comment",
+  "downvoted_collapsed_by_default",
   "show_comment_images",
   "show_community_icons",
   "show_hidden_in_communities",
@@ -676,6 +678,10 @@ export class WefwefDB extends Dexie {
         ++,
         &handle
       `,
+    });
+
+    this.version(10).upgrade(async () => {
+      await this.setSetting("downvoted_collapsed_by_default", false);
     });
   }
 


### PR DESCRIPTION
Closes #1838 

This is my first contribution, so it's very possible I've misunderstood something or not followed conventions in the project. As well as more substantive feedback, nitpicks are more than welcome - they help me learn!

<details><summary>About the `ppm-lcck.yaml` update</summary>
<p>

Also not entirely sure why, but the `pnpm-lock.yaml` needed updating. `pnpm i --frozen-lockfile` gave an error 
```
❯ pnpm i --frozen-lockfile
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile

Update your lockfile using "pnpm install --no-frozen-lockfile"
```
I I've put the changes to `pnpm-lock.yaml`  into a separate commit I can revert on request .

</p>
</details> 

The setting is off by default.

I've added `hasUserCollapsed` which is true if  the value for `commentId` in `state.comment.commentCollapsedById` has been defined. If it hasn't we're in the initial state of the comment (show unless downvoted & setting is set). If it has, the user must have shown/hidden the comment so we should use the state from `state.comment.commentCollapsedById` rather than the default.