### PR TITLE
refactor: revert "fix: css specificity not working during minification (#1756)"

### DIFF
--- a/src/features/comment/CommentHeader.module.css
+++ b/src/features/comment/CommentHeader.module.css
@@ -10,7 +10,7 @@
 }
 
 .personLink {
-  &.personLink {
+  && {
     color: var(--ion-text-color);
   }
 

--- a/src/features/community/titleSearch/TitleSearch.module.css
+++ b/src/features/community/titleSearch/TitleSearch.module.css
@@ -26,7 +26,7 @@
   text-align: inherit;
   outline: none;
 
-  &.input {
+  && {
     padding-top: 0;
     padding-bottom: 0;
   }

--- a/src/features/inbox/InboxItemMoreActions.module.css
+++ b/src/features/inbox/InboxItemMoreActions.module.css
@@ -1,7 +1,7 @@
 .button {
   composes: plainButton from "#/features/shared/shared.module.css";
 
-  &.button {
+  && {
     font-size: 1.12em;
   }
 }

--- a/src/features/media/video/Player.module.css
+++ b/src/features/media/video/Player.module.css
@@ -55,7 +55,7 @@
   top: 0;
   right: 0;
 
-  &.volumeButton {
+  && {
     padding: 14px;
     font-size: 26px;
     color: #aaa;

--- a/src/features/moderation/logs/ModlogItemMoreActions.module.css
+++ b/src/features/moderation/logs/ModlogItemMoreActions.module.css
@@ -1,7 +1,7 @@
 .button {
   composes: plainButton from "#/features/shared/shared.module.css";
 
-  &.button {
+  && {
     margin: -6px 0; /* prevent size from breaking line height */
   }
 }

--- a/src/features/post/crosspost/create/CreateCrosspostDialog.module.css
+++ b/src/features/post/crosspost/create/CreateCrosspostDialog.module.css
@@ -26,7 +26,7 @@
 .pillIonList {
   width: 100%;
 
-  &.pillIonList {
+  && {
     margin: 0;
   }
 }


### PR DESCRIPTION
This reverts commit b78ff280d11ed54a79f66ec94938f37a2a9904a6.

Workaround was fixed in vite 6.2: https://github.com/vitejs/vite/issues/18843