### PR TITLE
feat: add a post's alt-text to "Select Text" menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "voyager",
   "description": "A progressive webapp Lemmy client",
   "private": true,
-  "version": "2.39.3",
+  "version": "2.40.0",
   "type": "module",
   "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
   "scripts": {

--- a/src/features/settings/settingsSlice.tsx
+++ b/src/features/settings/settingsSlice.tsx
@@ -23,6 +23,7 @@ import {
   VgerPostSortTypeByMode,
 } from "#/features/feed/sort/PostSort";
 import { VgerSearchSortTypeByMode } from "#/features/feed/sort/SearchSort";
+import { isNative } from "#/helpers/device";
 import { MAX_DEFAULT_COMMENT_DEPTH } from "#/helpers/lemmy";
 import { DeepPartial } from "#/helpers/typescript";
 import { VgerCommunitySortTypeByMode } from "#/routes/pages/search/results/CommunitySort";
@@ -275,10 +276,9 @@ const baseState: SettingsState = {
     defaultFeed: undefined,
     // TODO: Enable by default in late June 2025
     // (devices have been updated to support go.getvoyager.app links)
-    // defaultShare: isNative()
-    //   ? OPostCommentShareType.DeepLink
-    //   : OPostCommentShareType.Local,
-    defaultShare: OPostCommentShareType.Local,
+    defaultShare: isNative()
+      ? OPostCommentShareType.DeepLink
+      : OPostCommentShareType.Local,
     enableHapticFeedback: true,
     linkHandler: OLinkHandlerType.InApp,
     media: {


### PR DESCRIPTION
Closes #2097 

This is my first contribution, so any feedback is welcome. For a quick one line fix, I found this to be a simple yet very useful feature addition.

Image posts sometimes include alt-text, which describes the image or transcribes its text for accessibility. Unfortunately, this text can't be copied, at least on the mobile version of Voyager. This means people sharing the image to other platforms need to manually retype the alt-text or not include it.

Currently, Voyager provides a "Select Text" menu to copy a post's title and description. This PR adds the post's alt-text to this menu.