### PR TITLE
chore: use macos-26 runner

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -86,7 +86,7 @@ jobs:
     concurrency:
       group: ios-release
     environment: deploy
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/