### PR TITLE
fix: hide mod chrome in share-as-image capture

### DIFF
--- a/src/features/comment/CommentHeader.tsx
+++ b/src/features/comment/CommentHeader.tsx
@@ -1,6 +1,6 @@
 import { IonIcon } from "@ionic/react";
 import { chevronDownOutline } from "ionicons/icons";
-import { RefObject } from "react";
+import { RefObject, use } from "react";
 import { Comment, CommentView } from "threadiverse";
 
 import Ago from "#/features/labels/Ago";
@@ -11,6 +11,7 @@ import ModqueueItemActions from "#/features/moderation/ModqueueItemActions";
 import { ModeratorRole } from "#/features/moderation/useCanModerate";
 import { ActionButton } from "#/features/post/actions/ActionButton";
 import ActionsContainer from "#/features/post/actions/ActionsContainer";
+import { ShareImageContext } from "#/features/share/asImage/ShareAsImage";
 import UserScore from "#/features/tags/UserScore";
 import UserTag from "#/features/tags/UserTag";
 import { cx } from "#/helpers/css";
@@ -43,6 +44,7 @@ export default function CommentHeader({
   rootIndex,
   commentEllipsisHandleRef,
 }: CommentHeaderProps) {
+  const { capturing } = use(ShareImageContext);
   const showCollapsedComment = useAppSelector(
     (state) => state.settings.general.comments.showCollapsed,
   );
@@ -53,6 +55,8 @@ export default function CommentHeader({
   );
 
   function renderActions() {
+    if (capturing) return;
+
     if (inModqueue) return <ModqueueItemActions itemView={commentView} />;
 
     if (canModerate)

--- a/src/features/moderation/ModeratableItem.tsx
+++ b/src/features/moderation/ModeratableItem.tsx
@@ -1,6 +1,7 @@
 import { createContext, ReactNode, use } from "react";
 import { CommentView, PostView } from "threadiverse";
 
+import { ShareImageContext } from "#/features/share/asImage/ShareAsImage";
 import { isPost } from "#/helpers/lemmy";
 import { useAppSelector } from "#/store";
 
@@ -51,6 +52,7 @@ export default function ModeratableItem({
   children,
   highlighted,
 }: ModeratableItemProps) {
+  const { capturing } = use(ShareImageContext);
   const canModerate = useCanModerate(itemView.community);
 
   const item = useAppSelector((state) => {
@@ -66,7 +68,7 @@ export default function ModeratableItem({
 
   const modState = useItemModState(item);
 
-  const shouldShowModBanner = canModerate && modState;
+  const shouldShowModBanner = canModerate && modState && !capturing;
 
   if (highlighted && !shouldShowModBanner) {
     return (


### PR DESCRIPTION
Skip moderator shield/queue actions in CommentHeader and suppress ModeratableItem report/removed banners when ShareImageContext.capturing.