### PR TITLE
feat: inline YouTube embeds in feed and post detail

### DIFF
--- a/src/features/media/external/youtube/LargeFeedYoutubeMedia.module.css
+++ b/src/features/media/external/youtube/LargeFeedYoutubeMedia.module.css
@@ -1,0 +1,41 @@
+.container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: black;
+  overflow: hidden;
+}
+
+.thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.playOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.25);
+  color: white;
+  transition: background 0.15s ease;
+}
+
+.playOverlay:hover {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.playIcon {
+  font-size: 72px;
+  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.6));
+}
+
+.iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}

--- a/src/features/media/external/youtube/LargeFeedYoutubeMedia.tsx
+++ b/src/features/media/external/youtube/LargeFeedYoutubeMedia.tsx
@@ -1,0 +1,93 @@
+import { IonIcon, useIonViewWillEnter } from "@ionic/react";
+import { playCircle } from "ionicons/icons";
+import {
+  CSSProperties,
+  MouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import CachedImg from "#/features/media/CachedImg";
+import BlurOverlay from "#/features/post/inFeed/large/media/BlurOverlay";
+import {
+  getYoutubeThumbnailSrc,
+  getYoutubeVideoId,
+} from "#/features/post/link/thumbnail/sites/youtube";
+import { cx } from "#/helpers/css";
+
+import { useYoutubePortal } from "./YoutubePortalProvider";
+
+import styles from "./LargeFeedYoutubeMedia.module.css";
+
+interface LargeFeedYoutubeMediaProps {
+  url: string;
+  blur?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  onClick?: (e: MouseEvent) => void;
+}
+
+export default function LargeFeedYoutubeMedia({
+  url,
+  blur,
+  className,
+  style,
+  onClick,
+}: LargeFeedYoutubeMediaProps) {
+  const videoId = getYoutubeVideoId(url);
+  const thumb = getYoutubeThumbnailSrc(url);
+  const slotRef = useRef<HTMLDivElement>(null);
+  const { hasActive, acquire, release } = useYoutubePortal(videoId);
+
+  const [thumbError, setThumbError] = useState(false);
+
+  // If another instance has already started playing this video, register our
+  // slot as a consumer so the overlay iframe can move over us when we become
+  // the active view.
+  useEffect(() => {
+    if (hasActive) acquire(slotRef);
+    return release;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [videoId]);
+
+  useIonViewWillEnter(() => {
+    if (hasActive) acquire(slotRef);
+  });
+
+  if (!videoId || !thumb || typeof thumb === "string") return;
+
+  const thumbSrc = thumbError ? thumb.sm : thumb.lg;
+
+  function handlePlay(e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    onClick?.(e);
+    acquire(slotRef);
+  }
+
+  const containerClass = cx(styles.container, className);
+
+  // Iframe is playing: render a slot that the overlay iframe visually covers.
+  if (hasActive) {
+    return <div ref={slotRef} className={containerClass} style={style} />;
+  }
+
+  const thumbnail = (
+    <div ref={slotRef} className={containerClass} style={style}>
+      <CachedImg
+        className={styles.thumbnail}
+        src={thumbSrc}
+        onError={() => setThumbError(true)}
+        draggable="false"
+      />
+      <div className={styles.playOverlay} onClick={handlePlay}>
+        <IonIcon icon={playCircle} className={styles.playIcon} />
+      </div>
+    </div>
+  );
+
+  if (blur) return <BlurOverlay src={thumbSrc}>{thumbnail}</BlurOverlay>;
+
+  return thumbnail;
+}

--- a/src/features/media/external/youtube/YoutubePortalProvider.module.css
+++ b/src/features/media/external/youtube/YoutubePortalProvider.module.css
@@ -1,0 +1,21 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+  border: 0;
+  pointer-events: auto;
+  background: black;
+  will-change: transform, width, height;
+}
+
+.hidden {
+  display: none;
+}

--- a/src/features/media/external/youtube/YoutubePortalProvider.tsx
+++ b/src/features/media/external/youtube/YoutubePortalProvider.tsx
@@ -1,0 +1,182 @@
+import { last, noop, without } from "es-toolkit";
+import {
+  createContext,
+  createRef,
+  RefObject,
+  use,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import styles from "./YoutubePortalProvider.module.css";
+
+interface VideoEntry {
+  consumerUids: string[];
+  slotRefs: Record<string, RefObject<HTMLElement | null>>;
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+}
+
+type VideoEntries = Record<string, VideoEntry>;
+
+interface YoutubePortalContextState {
+  entries: VideoEntries;
+  acquire: (
+    videoId: string,
+    uid: string,
+    slotRef: RefObject<HTMLElement | null>,
+  ) => void;
+  release: (videoId: string, uid: string) => void;
+}
+
+const YoutubePortalContext = createContext<YoutubePortalContextState>({
+  entries: {},
+  acquire: noop,
+  release: noop,
+});
+
+export default function YoutubePortalProvider({
+  children,
+}: React.PropsWithChildren) {
+  const [entries, _setEntries] = useState<VideoEntries>({});
+  const entriesRef = useRef(entries);
+
+  function setEntries(next: VideoEntries) {
+    entriesRef.current = next;
+    _setEntries(next);
+  }
+
+  useEffect(() => {
+    entriesRef.current = entries;
+  }, [entries]);
+
+  const acquire: YoutubePortalContextState["acquire"] = (
+    videoId,
+    uid,
+    slotRef,
+  ) => {
+    const current = entriesRef.current;
+    const existing = current[videoId];
+    if (existing) {
+      setEntries({
+        ...current,
+        [videoId]: {
+          ...existing,
+          consumerUids: [...without(existing.consumerUids, uid), uid],
+          slotRefs: { ...existing.slotRefs, [uid]: slotRef },
+        },
+      });
+      return;
+    }
+    const entry: VideoEntry = {
+      consumerUids: [uid],
+      slotRefs: { [uid]: slotRef },
+      iframeRef: createRef<HTMLIFrameElement>(),
+    };
+    setEntries({ ...current, [videoId]: entry });
+  };
+
+  const release: YoutubePortalContextState["release"] = (videoId, uid) => {
+    const current = entriesRef.current;
+    const existing = current[videoId];
+    if (!existing) return;
+    const remainingUids = without(existing.consumerUids, uid);
+    if (remainingUids.length === 0) {
+      const next = { ...current };
+      delete next[videoId];
+      setEntries(next);
+      return;
+    }
+    const nextSlotRefs = { ...existing.slotRefs };
+    delete nextSlotRefs[uid];
+    setEntries({
+      ...current,
+      [videoId]: {
+        ...existing,
+        consumerUids: remainingUids,
+        slotRefs: nextSlotRefs,
+      },
+    });
+  };
+
+  // RAF loop: position each iframe over its currently-active consumer slot.
+  // Direct DOM mutation — no React re-renders per frame.
+  useEffect(() => {
+    let raf = 0;
+    function tick() {
+      const current = entriesRef.current;
+      for (const [, entry] of Object.entries(current)) {
+        const iframe = entry.iframeRef.current;
+        if (!iframe) continue;
+
+        const activeUid = last(entry.consumerUids);
+        const slot = activeUid ? entry.slotRefs[activeUid]?.current : null;
+
+        if (!slot) {
+          if (!iframe.classList.contains(styles.hidden!)) {
+            iframe.classList.add(styles.hidden!);
+          }
+          continue;
+        }
+
+        const rect = slot.getBoundingClientRect();
+        const visible = rect.width > 0 && rect.height > 0;
+        if (!visible) {
+          if (!iframe.classList.contains(styles.hidden!)) {
+            iframe.classList.add(styles.hidden!);
+          }
+          continue;
+        }
+
+        if (iframe.classList.contains(styles.hidden!)) {
+          iframe.classList.remove(styles.hidden!);
+        }
+        iframe.style.transform = `translate(${rect.left}px, ${rect.top}px)`;
+        iframe.style.width = `${rect.width}px`;
+        iframe.style.height = `${rect.height}px`;
+      }
+      raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <YoutubePortalContext value={{ entries, acquire, release }}>
+      {children}
+      <div className={styles.overlay} aria-hidden>
+        {Object.entries(entries).map(([videoId, { iframeRef }]) => (
+          <iframe
+            key={videoId}
+            ref={iframeRef}
+            className={styles.iframe}
+            src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1&playsinline=1`}
+            title="YouTube video"
+            allow="autoplay; encrypted-media; fullscreen; picture-in-picture"
+            allowFullScreen
+          />
+        ))}
+      </div>
+    </YoutubePortalContext>
+  );
+}
+
+export function useYoutubePortal(videoId: string | undefined) {
+  const outPortalUid = useId();
+  const { entries, acquire, release } = use(YoutubePortalContext);
+
+  const entry = videoId ? entries[videoId] : undefined;
+  const hasActive = !!entry;
+
+  return {
+    outPortalUid,
+    hasActive,
+    acquire: (slotRef: RefObject<HTMLElement | null>) => {
+      if (videoId) acquire(videoId, outPortalUid, slotRef);
+    },
+    release: () => {
+      if (videoId) release(videoId, outPortalUid);
+    },
+  };
+}

--- a/src/features/post/inFeed/compact/Thumbnail.tsx
+++ b/src/features/post/inFeed/compact/Thumbnail.tsx
@@ -57,7 +57,8 @@ export default function Thumbnail({ post }: ImgProps) {
 
   const nsfw = isNsfwBlurred(post, blurNsfw);
 
-  const isLink = !postUrlIsMedia && post.post.url;
+  const isLink =
+    (!postUrlIsMedia || postUrlIsMedia === "youtube") && post.post.url;
 
   const handleLinkClick = (e: MouseEvent) => {
     e.stopPropagation();
@@ -85,7 +86,7 @@ export default function Thumbnail({ post }: ImgProps) {
       return <IonIcon className={styles.fullsizeIcon} icon={link} />;
     }
 
-    if (postUrlIsMedia) {
+    if (postUrlIsMedia && postUrlIsMedia !== "youtube") {
       return (
         <CompactFeedPostMedia
           post={post}

--- a/src/features/post/inFeed/large/media/LargeFeedPostMedia.tsx
+++ b/src/features/post/inFeed/large/media/LargeFeedPostMedia.tsx
@@ -3,7 +3,9 @@ import { PostView } from "threadiverse";
 
 import { isRedgif } from "#/features/media/external/redgifs/helpers";
 import LargeFeedRedgifMedia from "#/features/media/external/redgifs/LargeFeedRedgifMedia";
+import LargeFeedYoutubeMedia from "#/features/media/external/youtube/LargeFeedYoutubeMedia";
 import { buildMediaId } from "#/features/media/video/VideoPortalProvider";
+import { isYoutube } from "#/features/post/link/thumbnail/sites/youtube";
 import { cx } from "#/helpers/css";
 
 import usePostSrc from "../../usePostSrc";
@@ -30,6 +32,16 @@ export default function LargeFeedPostMedia(
             disableInlineInteraction={props.blur}
             className={cx(styles.lightbox, props.className)}
             portalWithMediaId={buildMediaId(props.post.post.ap_id)}
+          />
+        );
+      case isYoutube(props.post.post.url):
+        return (
+          <LargeFeedYoutubeMedia
+            url={props.post.post.url}
+            blur={props.blur}
+            className={cx(styles.lightbox, props.className)}
+            style={props.style}
+            onClick={props.onClick}
           />
         );
     }

--- a/src/features/post/link/thumbnail/sites/youtube.test.ts
+++ b/src/features/post/link/thumbnail/sites/youtube.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getYoutubeThumbnailSrc,
+  getYoutubeVideoId,
+  isYoutube,
+} from "./youtube";
+
+const ID = "dQw4w9WgXcQ";
+
+describe("getYoutubeVideoId", () => {
+  it("extracts id from youtube.com/watch?v=", () => {
+    expect(getYoutubeVideoId(`https://www.youtube.com/watch?v=${ID}`)).toBe(ID);
+  });
+
+  it("extracts id from youtu.be short links (with query params)", () => {
+    expect(getYoutubeVideoId(`https://youtu.be/${ID}?t=42`)).toBe(ID);
+  });
+
+  it("strips m. and music. subdomains", () => {
+    expect(getYoutubeVideoId(`https://m.youtube.com/watch?v=${ID}`)).toBe(ID);
+    expect(getYoutubeVideoId(`https://music.youtube.com/watch?v=${ID}`)).toBe(
+      ID,
+    );
+  });
+
+  it("extracts id from /embed/, /v/, /shorts/, /live/ paths", () => {
+    for (const path of ["embed", "v", "shorts", "live"]) {
+      expect(getYoutubeVideoId(`https://www.youtube.com/${path}/${ID}`)).toBe(
+        ID,
+      );
+    }
+  });
+
+  it("extracts id from alternate hosts (nocookie, kids, yt.be)", () => {
+    expect(
+      getYoutubeVideoId(`https://www.youtube-nocookie.com/embed/${ID}`),
+    ).toBe(ID);
+    expect(getYoutubeVideoId(`https://www.youtubekids.com/watch?v=${ID}`)).toBe(
+      ID,
+    );
+    expect(getYoutubeVideoId(`https://yt.be/${ID}`)).toBe(ID);
+  });
+
+  it("extracts id from country TLDs", () => {
+    expect(getYoutubeVideoId(`https://www.youtube.de/watch?v=${ID}`)).toBe(ID);
+    expect(getYoutubeVideoId(`https://www.youtube.co.uk/watch?v=${ID}`)).toBe(
+      ID,
+    );
+  });
+
+  it("handles URLs without a protocol", () => {
+    expect(getYoutubeVideoId(`youtube.com/watch?v=${ID}`)).toBe(ID);
+  });
+
+  it("is case-insensitive on the host but preserves id case", () => {
+    expect(getYoutubeVideoId(`https://YouTube.com/watch?v=AbCdEfGhIjK`)).toBe(
+      "AbCdEfGhIjK",
+    );
+  });
+
+  it("rejects non-youtube and youtube-lookalike hosts", () => {
+    expect(getYoutubeVideoId(`https://vimeo.com/${ID}`)).toBeUndefined();
+    expect(
+      getYoutubeVideoId(`https://notyoutube.com/watch?v=${ID}`),
+    ).toBeUndefined();
+    expect(
+      getYoutubeVideoId(`https://youtube.evil.com/watch?v=${ID}`),
+    ).toBeUndefined();
+  });
+
+  it("rejects invalid ids (wrong length or illegal chars)", () => {
+    expect(getYoutubeVideoId(`https://youtu.be/tooShort`)).toBeUndefined();
+    expect(
+      getYoutubeVideoId(`https://www.youtube.com/watch?v=!!!!!!!!!!!`),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for youtube urls with no extractable id", () => {
+    expect(
+      getYoutubeVideoId(`https://www.youtube.com/feed/trending`),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for garbage input", () => {
+    expect(getYoutubeVideoId("not a url at all !!!")).toBeUndefined();
+    expect(getYoutubeVideoId("")).toBeUndefined();
+  });
+});
+
+describe("isYoutube", () => {
+  it("is true for recognizable youtube urls, false otherwise", () => {
+    expect(isYoutube(`https://youtu.be/${ID}`)).toBe(true);
+    expect(isYoutube(`https://www.youtube.com/shorts/${ID}`)).toBe(true);
+    expect(isYoutube("https://example.com")).toBe(false);
+    expect(isYoutube("https://www.youtube.com/feed/trending")).toBe(false);
+  });
+});
+
+describe("getYoutubeThumbnailSrc", () => {
+  it("returns both sm and lg thumbnail urls for a valid video", () => {
+    expect(getYoutubeThumbnailSrc(`https://youtu.be/${ID}`)).toEqual({
+      sm: `https://img.youtube.com/vi/${ID}/mqdefault.jpg`,
+      lg: `https://img.youtube.com/vi/${ID}/maxresdefault.jpg`,
+    });
+  });
+
+  it("returns undefined when the url has no extractable id", () => {
+    expect(getYoutubeThumbnailSrc("https://example.com")).toBeUndefined();
+  });
+});

--- a/src/features/post/link/thumbnail/sites/youtube.ts
+++ b/src/features/post/link/thumbnail/sites/youtube.ts
@@ -3,16 +3,54 @@ import { Thumbnail } from "../thumbnailinator";
 export default function determineThumbnailForYoutube(
   url: string,
 ): Thumbnail | undefined {
-  const videoId = getYoutubeVideoId(url);
-  if (videoId) return getYoutubeThumbnailSrc(url);
+  if (getYoutubeVideoId(url)) return getYoutubeThumbnailSrc(url);
 }
 
-// https://stackoverflow.com/a/61033353/1319878
-const YOUTUBE_LINK =
-  /(?:https?:\/\/)?(?:www\.)?youtu(?:\.be\/|be.com\/\S*(?:watch|embed)(?:(?:(?=\/[-a-zA-Z0-9_]{11,}(?!\S))\/)|(?:\S*v=|v\/)))([-a-zA-Z0-9_]{11,})/;
+const YOUTUBE_HOSTS_EXACT = new Set([
+  "youtu.be",
+  "yt.be",
+  "youtube-nocookie.com",
+  "youtubekids.com",
+]);
+
+// e.g. youtube.com, youtube.de, youtube.co.uk, youtube.com.br
+const YOUTUBE_TLD_HOST = /^youtube\.(?:[a-z]{2,3}|(?:co|com)\.[a-z]{2})$/;
+
+const STRIP_SUBDOMAIN = /^(?:www|m|music)\./;
+
+const VIDEO_ID = /^[-a-zA-Z0-9_]{11}$/;
+
+export function isYoutube(url: string): boolean {
+  return !!getYoutubeVideoId(url);
+}
 
 export function getYoutubeVideoId(url: string): string | undefined {
-  return url.match(YOUTUBE_LINK)?.[1];
+  let parsed: URL;
+  try {
+    parsed = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
+  } catch {
+    return;
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(STRIP_SUBDOMAIN, "");
+
+  const isYoutubeHost =
+    YOUTUBE_HOSTS_EXACT.has(host) || YOUTUBE_TLD_HOST.test(host);
+  if (!isYoutubeHost) return;
+
+  if (host === "youtu.be" || host === "yt.be") {
+    const id = parsed.pathname.slice(1).split("/")[0];
+    return id && VIDEO_ID.test(id) ? id : undefined;
+  }
+
+  const v = parsed.searchParams.get("v");
+  if (v && VIDEO_ID.test(v)) return v;
+
+  const pathMatch = parsed.pathname.match(
+    /^\/(?:embed|v|shorts|live)\/([^/?#]+)/,
+  );
+  const pathId = pathMatch?.[1];
+  if (pathId && VIDEO_ID.test(pathId)) return pathId;
 }
 
 export function getYoutubeThumbnailSrc(url: string): Thumbnail | undefined {

--- a/src/features/post/usePostUrlIsMedia.ts
+++ b/src/features/post/usePostUrlIsMedia.ts
@@ -1,6 +1,7 @@
 import { PostView } from "threadiverse";
 
 import { isRedgif } from "#/features/media/external/redgifs/helpers";
+import { isYoutube } from "#/features/post/link/thumbnail/sites/youtube";
 import { findLoneImage } from "#/helpers/markdown";
 import { findUrlMediaType } from "#/helpers/url";
 import { useAppSelector } from "#/store";
@@ -19,6 +20,7 @@ export default function usePostUrlIsMedia(post: PostView) {
 
     if (embedExternalMedia) {
       if (isRedgif(url)) return "from-url";
+      if (isYoutube(url)) return "youtube";
     }
   } else {
     if (body && findLoneImage(body)) return "from-body";

--- a/src/features/settings/appearance/posts/EmbedExternalMedia.tsx
+++ b/src/features/settings/appearance/posts/EmbedExternalMedia.tsx
@@ -1,6 +1,5 @@
 import { IonItem, IonToggle } from "@ionic/react";
 
-import { platformSupportsRedgif } from "#/features/media/external/redgifs/helpers";
 import { resetRedgifs } from "#/features/media/external/redgifs/redgifsSlice";
 import { useAppDispatch, useAppSelector } from "#/store";
 
@@ -11,8 +10,6 @@ export default function EmbedExternalMedia() {
   const embedExternalMedia = useAppSelector(
     (state) => state.settings.appearance.posts.embedExternalMedia,
   );
-
-  if (!platformSupportsRedgif()) return;
 
   return (
     <IonItem>

--- a/src/routes/TabbedRoutes.tsx
+++ b/src/routes/TabbedRoutes.tsx
@@ -4,6 +4,7 @@ import { use, useEffect } from "react";
 
 import { TabContext } from "#/core/TabContext";
 import { instanceSelector } from "#/features/auth/authSelectors";
+import YoutubePortalProvider from "#/features/media/external/youtube/YoutubePortalProvider";
 import GalleryProvider from "#/features/media/gallery/GalleryProvider";
 import VideoPortalProvider from "#/features/media/video/VideoPortalProvider";
 import { useOptimizedIonRouter } from "#/helpers/useOptimizedIonRouter";
@@ -33,12 +34,14 @@ export default function TabbedRoutes({ children }: React.PropsWithChildren) {
     <>
       {children}
       <VideoPortalProvider>
-        <GalleryProvider>
-          <InnerTabbedRoutes
-            // Rebuild routing on instance change
-            key={selectedInstance ?? getDefaultServer()}
-          />
-        </GalleryProvider>
+        <YoutubePortalProvider>
+          <GalleryProvider>
+            <InnerTabbedRoutes
+              // Rebuild routing on instance change
+              key={selectedInstance ?? getDefaultServer()}
+            />
+          </GalleryProvider>
+        </YoutubePortalProvider>
       </VideoPortalProvider>
     </>
   );


### PR DESCRIPTION
## Summary

- Play YouTube videos inline in the Large feed layout and post detail view, instead of bouncing out to YouTube.
- Click-to-play: each post shows the YouTube thumbnail with a play overlay; the `youtube-nocookie.com` iframe only loads after a tap, so scrolling never pings Google.
- Gated by the existing **Embed External Media** setting (same toggle as Redgifs) — no new setting.
- A small portal provider keeps a single iframe per video and reparents it over the currently-visible slot, so playback survives feed ↔ post detail navigation. Videos stop when the slot unmounts (e.g. virtualized scroll).
- Compact layout is intentionally unchanged — YouTube posts still render as a link thumbnail there.
- Removed the `platformSupportsRedgif()` gate on the Embed External Media toggle so it shows on web (YouTube doesn't need the native CORS bypass Redgifs does).

URL detection covers: `youtube.com`, `youtu.be`, `m.` / `music.` subdomains, `youtube-nocookie.com`, `youtubekids.com`, `yt.be`, country TLDs (`.de`, `.co.uk`, etc.), and `/watch`, `/embed/`, `/v/`, `/shorts/`, `/live/` paths.

## Test plan

- [ ] With **Embed External Media** on, Large feed: YouTube posts show a thumbnail + play overlay; tapping loads the iframe and autoplays.
- [ ] Tapping elsewhere on the post still navigates to post detail; the running video follows and keeps playing.
- [ ] Back-navigating to the feed keeps the video playing in place.
- [ ] Scrolling the video out of the virtualized feed unmounts it (playback stops, restarts from zero on scroll-back).
- [ ] With the setting **off**, YouTube posts render as a plain link preview in every layout.
- [ ] Compact layout is unchanged regardless of the setting.
- [ ] NSFW YouTube post renders through `BlurOverlay` like other media.
- [ ] DevTools Network: no requests to YouTube on scroll — only after tapping play, and only to `youtube-nocookie.com`.
- [ ] `pnpm test` and `pnpm test:typecheck` pass. 15 new unit tests cover the URL detector (including a rejection for lookalike hosts like `youtube.evil.com`).

## Notes

- No CSP changes needed (`index.html` has no CSP today).
- YouTube Shorts URLs (`/shorts/{id}`) are matched; YouTube Music URLs on `music.youtube.com` also work.
- Lookalike-host rejection caught a real regex bug during review — `/^youtube(?:\.[a-z]{2,4}){1,2}$/` was too permissive and matched `youtube.evil.com`; tightened to `/^youtube\.(?:[a-z]{2,3}|(?:co|com)\.[a-z]{2})$/`.