### PR TITLE
feat: respect provider capabilities

### DIFF
--- a/e2e/lemmyv1/journey.spec.ts
+++ b/e2e/lemmyv1/journey.spec.ts
@@ -1,5 +1,6 @@
-// Modlog walk-through against the v1 wire fixtures. Modlog has no seed
-// support and PieFed derives no modlog, so this stays provider-specific.
+// Modlog walk-through against the v1 wire fixtures. The PieFed fake now
+// supports modlog too, but this stays provider-specific because it asserts
+// v1-specific seeded action kinds and rendered copy.
 // The rest of the journey (feed list, post detail body/author/comment, user
 // profile) is provider-agnostic and covered by e2e/matrix/{post-feed,smoke}.
 

--- a/src/features/auth/login/pickJoinServer/registrationSupport.test.ts
+++ b/src/features/auth/login/pickJoinServer/registrationSupport.test.ts
@@ -1,0 +1,65 @@
+import type { ThreadiverseClient } from "threadiverse";
+import { describe, expect, it, vi } from "vitest";
+
+import { preflightRegistrationSupport } from "./registrationSupport";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createClient(supported: boolean) {
+  const supports = vi.fn(async () => supported);
+
+  return {
+    client: { supports } as unknown as Pick<ThreadiverseClient, "supports">,
+    supports,
+  };
+}
+
+describe("preflightRegistrationSupport", () => {
+  it.each([
+    [true, "supported"],
+    [false, "unsupported"],
+  ] as const)("maps register support %s to %s", async (supported, expected) => {
+    const { client, supports } = createClient(supported);
+
+    await expect(
+      preflightRegistrationSupport(client, () => true),
+    ).resolves.toBe(expected);
+    expect(supports).toHaveBeenCalledExactlyOnceWith("register");
+  });
+
+  it("does not query a client whose selection is already stale", async () => {
+    const { client, supports } = createClient(true);
+
+    await expect(
+      preflightRegistrationSupport(client, () => false),
+    ).resolves.toBe("stale");
+    expect(supports).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "ignores a result of %s after the selected client changes",
+    async (supported) => {
+      const result = deferred<boolean>();
+      const supports = vi.fn(() => result.promise);
+      const client = {
+        supports,
+      } as unknown as Pick<ThreadiverseClient, "supports">;
+      let current = true;
+
+      const preflight = preflightRegistrationSupport(client, () => current);
+
+      expect(supports).toHaveBeenCalledWith("register");
+      current = false;
+      result.resolve(supported);
+
+      await expect(preflight).resolves.toBe("stale");
+    },
+  );
+});

--- a/src/features/auth/login/pickJoinServer/registrationSupport.ts
+++ b/src/features/auth/login/pickJoinServer/registrationSupport.ts
@@ -1,0 +1,20 @@
+import type { ThreadiverseClient } from "threadiverse";
+
+export type RegistrationSupport = "stale" | "supported" | "unsupported";
+
+/**
+ * Preflight signup support without applying a result to a client selection
+ * that changed while capability discovery was in flight.
+ */
+export async function preflightRegistrationSupport(
+  client: Pick<ThreadiverseClient, "supports">,
+  isCurrentClient: () => boolean,
+): Promise<RegistrationSupport> {
+  if (!isCurrentClient()) return "stale";
+
+  const supported = await client.supports("register");
+
+  if (!isCurrentClient()) return "stale";
+
+  return supported ? "supported" : "unsupported";
+}

--- a/src/features/auth/login/pickJoinServer/useStartJoinFlow.tsx
+++ b/src/features/auth/login/pickJoinServer/useStartJoinFlow.tsx
@@ -10,6 +10,8 @@ import Legal from "#/features/auth/login/join/Legal";
 import useAppToast from "#/helpers/useAppToast";
 import store, { useAppDispatch } from "#/store";
 
+import { preflightRegistrationSupport } from "./registrationSupport";
+
 export default function useStartJoinFlow(ref: RefObject<HTMLElement | null>) {
   const presentToast = useAppToast();
   const [presentAlert] = useIonAlert();
@@ -31,12 +33,29 @@ export default function useStartJoinFlow(ref: RefObject<HTMLElement | null>) {
       throw error;
     }
 
-    if (
-      site &&
-      (await joinClientSelector(store.getState())?.connect())?.mode === "piefed"
-    ) {
+    const selectedState = store.getState();
+    const client = joinClientSelector(selectedState);
+    const isCurrentClient = () => {
+      const currentState = store.getState();
+
+      return (
+        currentState.join.url === url &&
+        joinClientSelector(currentState) === client
+      );
+    };
+
+    if (!site || !client || !isCurrentClient()) return;
+
+    const registrationSupport = await preflightRegistrationSupport(
+      client,
+      isCurrentClient,
+    );
+
+    if (registrationSupport === "stale") return;
+
+    if (registrationSupport === "unsupported") {
       presentAlert(
-        `Voyager doesn't support signups via Piefed right now, apologies!`,
+        `Voyager doesn't support signups through this server right now, apologies!`,
       );
 
       return;

--- a/src/features/auth/login/pickJoinServer/useStartJoinFlow.tsx
+++ b/src/features/auth/login/pickJoinServer/useStartJoinFlow.tsx
@@ -46,17 +46,30 @@ export default function useStartJoinFlow(ref: RefObject<HTMLElement | null>) {
 
     if (!site || !client || !isCurrentClient()) return;
 
-    const registrationSupport = await preflightRegistrationSupport(
-      client,
-      isCurrentClient,
-    );
+    let registrationSupport: Awaited<
+      ReturnType<typeof preflightRegistrationSupport>
+    >;
+    try {
+      registrationSupport = await preflightRegistrationSupport(
+        client,
+        isCurrentClient,
+      );
+    } catch (error) {
+      if (!isCurrentClient()) return;
+
+      presentToast({
+        message: `Problem connecting to ${url}. Please try again later.`,
+        position: "top",
+        color: "danger",
+        fullscreen: true,
+      });
+      throw error;
+    }
 
     if (registrationSupport === "stale") return;
 
     if (registrationSupport === "unsupported") {
-      presentAlert(
-        `Voyager doesn't support signups through this server right now, apologies!`,
-      );
+      presentAlert(`Voyager can't create accounts on ${url}.`);
 
       return;
     }

--- a/src/features/feed/sort/useFeedSort.test.ts
+++ b/src/features/feed/sort/useFeedSort.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getProfileCommentSort,
+  getProfileCommentSortParams,
+  getProfilePostSort,
+  getProfilePostSortParams,
+} from "./useFeedSort";
+
+describe("profile feed sort params", () => {
+  it("uses the Lemmy v0 post vocabulary for profile posts", () => {
+    expect(getProfilePostSortParams("lemmyv0", "ControversialAll")).toEqual({
+      mode: "lemmyv0",
+      sort: "Controversial",
+    });
+  });
+
+  it("maps Lemmy v0's comment Top choice to the post-sort equivalent", () => {
+    expect(getProfileCommentSortParams("lemmyv0", "Top")).toEqual({
+      mode: "lemmyv0",
+      sort: "TopAll",
+    });
+  });
+
+  it("omits sort from Lemmy v1 profile requests", () => {
+    expect(getProfilePostSortParams("lemmyv1", "TopWeek")).toEqual({
+      mode: "lemmyv1",
+    });
+    expect(getProfileCommentSortParams("lemmyv1", "Hot")).toEqual({
+      mode: "lemmyv1",
+    });
+  });
+
+  it("uses PieFed's route-specific post and comment sorts", () => {
+    expect(getProfilePostSortParams("piefed", "TopWeek")).toEqual({
+      mode: "piefed",
+      sort: "TopWeek",
+    });
+    expect(getProfileCommentSortParams("piefed", "Old")).toEqual({
+      mode: "piefed",
+      sort: "Old",
+    });
+  });
+
+  it("resets a remembered sort that is invalid for the active provider", () => {
+    expect(getProfilePostSort("piefed", "MostComments")).toBe("New");
+    expect(getProfilePostSortParams("piefed", "MostComments")).toEqual({
+      mode: "piefed",
+      sort: "New",
+    });
+    expect(getProfileCommentSort("piefed", "Controversial")).toBe("New");
+    expect(getProfileCommentSortParams("piefed", "Controversial")).toEqual({
+      mode: "piefed",
+      sort: "New",
+    });
+  });
+
+  it("waits for the active mode and remembered sort to resolve", () => {
+    expect(getProfilePostSort(undefined, "New")).toBeUndefined();
+    expect(getProfilePostSortParams("piefed", undefined)).toBeUndefined();
+    expect(getProfileCommentSortParams("lemmyv0", null)).toBeNull();
+  });
+});

--- a/src/features/feed/sort/useFeedSort.tsx
+++ b/src/features/feed/sort/useFeedSort.tsx
@@ -22,10 +22,6 @@ import {
   VgerCommunitySortType,
   VgerCommunitySortTypeByMode,
 } from "#/routes/pages/search/results/CommunitySort";
-import {
-  AnyVgerSort,
-  findSortOptionUnhydrated,
-} from "#/routes/pages/shared/Sort";
 import { useAppDispatch, useAppSelector } from "#/store";
 
 import { AnyFeed } from "../helpers";
@@ -68,6 +64,32 @@ interface Sorts {
   comments: CommentSortType;
   search: SearchSortType;
   communities: CommunitySortType;
+}
+
+type AnyVgerSort =
+  | VgerPostSortType
+  | VgerCommentSortType
+  | VgerSearchSortType
+  | VgerCommunitySortType;
+
+type UnhydratedSortOptions<S> = readonly (S | { children: readonly S[] })[];
+
+function findSortOptionUnhydrated<S>(
+  sort: unknown,
+  sortOptions: UnhydratedSortOptions<S>,
+): S | undefined {
+  for (const option of sortOptions) {
+    if (typeof option === "string") {
+      if (option === sort) return option;
+    } else if (
+      typeof option === "object" &&
+      option !== null &&
+      "children" in option
+    ) {
+      const matchingChild = option.children.find((child) => child === sort);
+      if (matchingChild) return matchingChild;
+    }
+  }
 }
 
 export type FeedSortContext = "posts" | "comments" | "search" | "communities";

--- a/src/features/feed/sort/useFeedSort.tsx
+++ b/src/features/feed/sort/useFeedSort.tsx
@@ -4,6 +4,7 @@ import {
   CommentSortTypeByMode,
   CommunitySortType,
   CommunitySortTypeByMode,
+  ListPersonContentByMode,
   PostSortType,
   PostSortTypeByMode,
   SearchSortType,
@@ -12,6 +13,7 @@ import {
 } from "threadiverse";
 
 import {
+  COMMENT_SORT_BY_MODE,
   VgerCommentSortType,
   VgerCommentSortTypeByMode,
 } from "#/features/comment/CommentSort";
@@ -20,7 +22,10 @@ import {
   VgerCommunitySortType,
   VgerCommunitySortTypeByMode,
 } from "#/routes/pages/search/results/CommunitySort";
-import { AnyVgerSort } from "#/routes/pages/shared/Sort";
+import {
+  AnyVgerSort,
+  findSortOptionUnhydrated,
+} from "#/routes/pages/shared/Sort";
 import { useAppDispatch, useAppSelector } from "#/store";
 
 import { AnyFeed } from "../helpers";
@@ -36,7 +41,11 @@ import {
   setFeedSort,
   SetSortActionPayload,
 } from "./feedSortSlice";
-import { VgerPostSortType, VgerPostSortTypeByMode } from "./PostSort";
+import {
+  POST_SORT_BY_MODE,
+  VgerPostSortType,
+  VgerPostSortTypeByMode,
+} from "./PostSort";
 import { VgerSearchSortType, VgerSearchSortTypeByMode } from "./SearchSort";
 import { isTopSort, topSortToDuration, VgerTopSort } from "./topSorts";
 
@@ -196,6 +205,93 @@ export function useFeedSortParams<Context extends FeedSortContext>(
   if (!sort) return sort;
 
   return convertSortToLemmyParams(context, sort, mode) ?? null;
+}
+
+type ProfileFeedSortParams<ContentType extends "comments" | "posts"> =
+  | Pick<ListPersonContentByMode["lemmyv0"], "mode" | "sort">
+  | Pick<ListPersonContentByMode["lemmyv1"], "mode">
+  | Pick<
+      Extract<ListPersonContentByMode["piefed"], { type: ContentType }>,
+      "mode" | "sort"
+    >;
+
+/** Resolve a remembered profile-post sort for the active provider. */
+export function getProfilePostSort(
+  mode: ThreadiverseMode | null | undefined,
+  sort: VgerPostSortType | null | undefined,
+): VgerPostSortType | null | undefined {
+  if (!mode) return mode;
+  if (!sort) return sort;
+
+  if (mode === "lemmyv1") return "New";
+
+  return findSortOptionUnhydrated(sort, POST_SORT_BY_MODE[mode]) ?? "New";
+}
+
+/** Convert Voyager's post sort to the provider-specific profile-feed route. */
+export function getProfilePostSortParams(
+  mode: ThreadiverseMode | null | undefined,
+  sort: VgerPostSortType | null | undefined,
+): ProfileFeedSortParams<"posts"> | null | undefined {
+  if (!mode) return mode;
+
+  const validSort = getProfilePostSort(mode, sort);
+  if (!validSort) return validSort;
+
+  switch (mode) {
+    case "lemmyv0": {
+      const providerSort =
+        findSortOptionUnhydrated(validSort, POST_SORT_BY_MODE.lemmyv0) ?? "New";
+      return convertPostSortToLemmyV0Params(providerSort);
+    }
+    case "lemmyv1":
+      // Lemmy v1's person-content route has no sort parameter.
+      return { mode };
+    case "piefed": {
+      const providerSort =
+        findSortOptionUnhydrated(validSort, POST_SORT_BY_MODE.piefed) ?? "New";
+      return convertPostSortToPiefedParams(providerSort);
+    }
+  }
+}
+
+/** Resolve a remembered profile-comment sort for the active provider. */
+export function getProfileCommentSort(
+  mode: ThreadiverseMode | null | undefined,
+  sort: VgerCommentSortType | null | undefined,
+): VgerCommentSortType | null | undefined {
+  if (!mode) return mode;
+  if (!sort) return sort;
+
+  if (mode === "lemmyv1") return "New";
+
+  return findSortOptionUnhydrated(sort, COMMENT_SORT_BY_MODE[mode]) ?? "New";
+}
+
+/** Convert Voyager's comment sort to the provider-specific profile-feed route. */
+export function getProfileCommentSortParams(
+  mode: ThreadiverseMode | null | undefined,
+  sort: VgerCommentSortType | null | undefined,
+): ProfileFeedSortParams<"comments"> | null | undefined {
+  if (!mode) return mode;
+
+  const validSort = getProfileCommentSort(mode, sort);
+  if (!validSort) return validSort;
+
+  switch (mode) {
+    case "lemmyv0": {
+      // Lemmy v0's getPersonDetails route uses its post-sort vocabulary.
+      return {
+        mode,
+        sort: validSort === "Top" ? "TopAll" : validSort,
+      };
+    }
+    case "lemmyv1":
+      // Lemmy v1's person-content route has no sort parameter.
+      return { mode };
+    case "piefed":
+      return { mode, sort: validSort };
+  }
 }
 
 function convertSortToLemmyParams<Context extends FeedSortContext>(

--- a/src/features/inbox/inboxSlice.test.ts
+++ b/src/features/inbox/inboxSlice.test.ts
@@ -1,0 +1,171 @@
+import { UnsupportedError } from "threadiverse";
+import type { ThreadiverseClient } from "threadiverse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppDispatch, RootState } from "#/store";
+
+import { markNotificationRead, setNotificationReadStatus } from "./inboxSlice";
+
+const selectedClient = vi.hoisted(() => ({
+  current: undefined as unknown as ThreadiverseClient,
+}));
+
+vi.mock("#/features/auth/authSelectors", async (importOriginal) => ({
+  ...(await importOriginal()),
+  clientSelector: () => selectedClient.current,
+  jwtSelector: () => "test-jwt",
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createClient() {
+  const supports = vi.fn(async () => true);
+  const markNotificationAsRead = vi.fn(async (): Promise<void> => undefined);
+
+  return {
+    client: {
+      markNotificationAsRead,
+      supports,
+    } as unknown as ThreadiverseClient,
+    markNotificationAsRead,
+    supports,
+  };
+}
+
+function createState(auth: object, read = false): RootState {
+  return {
+    auth,
+    inbox: {
+      readByInboxItemId: { mod_action_42: read },
+    },
+  } as unknown as RootState;
+}
+
+describe("markNotificationRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects an unsupported notification kind before optimistic or remote writes", async () => {
+    const { client, markNotificationAsRead, supports } = createClient();
+    supports.mockResolvedValue(false);
+    selectedClient.current = client;
+
+    const state = createState({ activeHandle: "me@piefed.example" });
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await expect(
+      markNotificationRead({ kind: "mod_action", notificationId: 42 }, true)(
+        dispatch,
+        () => state,
+      ),
+    ).rejects.toBeInstanceOf(UnsupportedError);
+
+    expect(supports).toHaveBeenCalledWith("markNotificationAsRead", {
+      kind: "mod_action",
+      notification_id: 42,
+      read: true,
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(markNotificationAsRead).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "does not apply stale state after an account switch when preflight resolves %s",
+    async (supported) => {
+      const supportResult = deferred<boolean>();
+      const first = createClient();
+      const second = createClient();
+      first.supports.mockReturnValue(supportResult.promise);
+      selectedClient.current = first.client;
+
+      let state = createState({ activeHandle: "first@example.com" });
+      const dispatch = vi.fn() as unknown as AppDispatch;
+      const result = markNotificationRead(
+        { kind: "reply", notificationId: 42 },
+        true,
+      )(dispatch, () => state);
+
+      expect(dispatch).not.toHaveBeenCalled();
+
+      state = createState({ activeHandle: "second@example.com" });
+      selectedClient.current = second.client;
+      supportResult.resolve(supported);
+      await result;
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(first.markNotificationAsRead).not.toHaveBeenCalled();
+      expect(second.markNotificationAsRead).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not roll a failed old request back into a newly selected account", async () => {
+    const endpointResult = deferred<void>();
+    const first = createClient();
+    const second = createClient();
+    first.markNotificationAsRead.mockReturnValue(endpointResult.promise);
+    selectedClient.current = first.client;
+
+    let state = createState({ activeHandle: "first@example.com" });
+    const dispatch = vi.fn() as unknown as AppDispatch;
+    const result = markNotificationRead(
+      { kind: "reply", notificationId: 42 },
+      true,
+    )(dispatch, () => state);
+
+    await vi.waitFor(() => {
+      expect(first.markNotificationAsRead).toHaveBeenCalledOnce();
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      setNotificationReadStatus({
+        kind: "reply",
+        notificationId: 42,
+        read: true,
+      }),
+    );
+
+    state = createState({ activeHandle: "second@example.com" });
+    selectedClient.current = second.client;
+    const endpointError = new Error("request failed");
+    endpointResult.reject(endpointError);
+
+    await expect(result).rejects.toBe(endpointError);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh counts for an old request after an account switch", async () => {
+    const endpointResult = deferred<void>();
+    const first = createClient();
+    const second = createClient();
+    first.markNotificationAsRead.mockReturnValue(endpointResult.promise);
+    selectedClient.current = first.client;
+
+    let state = createState({ activeHandle: "first@example.com" });
+    const dispatch = vi.fn() as unknown as AppDispatch;
+    const result = markNotificationRead(
+      { kind: "reply", notificationId: 42 },
+      true,
+    )(dispatch, () => state);
+
+    await vi.waitFor(() => {
+      expect(first.markNotificationAsRead).toHaveBeenCalledOnce();
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    state = createState({ activeHandle: "second@example.com" });
+    selectedClient.current = second.client;
+    endpointResult.resolve();
+
+    await result;
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/inbox/inboxSlice.test.ts
+++ b/src/features/inbox/inboxSlice.test.ts
@@ -100,7 +100,7 @@ describe("markNotificationRead", () => {
       state = createState({ activeHandle: "second@example.com" });
       selectedClient.current = second.client;
       supportResult.resolve(supported);
-      await result;
+      await expect(result).resolves.toBe(false);
 
       expect(dispatch).not.toHaveBeenCalled();
       expect(first.markNotificationAsRead).not.toHaveBeenCalled();
@@ -138,8 +138,67 @@ describe("markNotificationRead", () => {
     const endpointError = new Error("request failed");
     endpointResult.reject(endpointError);
 
-    await expect(result).rejects.toBe(endpointError);
+    await expect(result).resolves.toBe(false);
     expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses a failed old preflight after an account switch", async () => {
+    const supportResult = deferred<boolean>();
+    const first = createClient();
+    const second = createClient();
+    first.supports.mockReturnValue(supportResult.promise);
+    selectedClient.current = first.client;
+
+    let state = createState({ activeHandle: "first@example.com" });
+    const dispatch = vi.fn() as unknown as AppDispatch;
+    const result = markNotificationRead(
+      { kind: "reply", notificationId: 42 },
+      true,
+    )(dispatch, () => state);
+
+    await vi.waitFor(() => expect(first.supports).toHaveBeenCalledOnce());
+
+    state = createState({ activeHandle: "second@example.com" });
+    selectedClient.current = second.client;
+    supportResult.reject(new Error("old discovery failed"));
+
+    await expect(result).resolves.toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(first.markNotificationAsRead).not.toHaveBeenCalled();
+  });
+
+  it("rolls back and propagates a failed request for the active account", async () => {
+    const endpointError = new Error("active request failed");
+    const first = createClient();
+    first.markNotificationAsRead.mockRejectedValue(endpointError);
+    selectedClient.current = first.client;
+
+    const state = createState({ activeHandle: "first@example.com" });
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await expect(
+      markNotificationRead({ kind: "reply", notificationId: 42 }, true)(
+        dispatch,
+        () => state,
+      ),
+    ).rejects.toBe(endpointError);
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+      1,
+      setNotificationReadStatus({
+        kind: "reply",
+        notificationId: 42,
+        read: true,
+      }),
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      2,
+      setNotificationReadStatus({
+        kind: "reply",
+        notificationId: 42,
+        read: false,
+      }),
+    );
   });
 
   it("does not refresh counts for an old request after an account switch", async () => {
@@ -165,7 +224,7 @@ describe("markNotificationRead", () => {
     selectedClient.current = second.client;
     endpointResult.resolve();
 
-    await result;
+    await expect(result).resolves.toBe(false);
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/inbox/inboxSlice.ts
+++ b/src/features/inbox/inboxSlice.ts
@@ -321,14 +321,19 @@ export const markNotificationRead =
       notification_id: args.notificationId,
       read,
     };
-
-    const supported = await client.supports("markNotificationAsRead", payload);
-
     const isCurrentClient = () => clientSelector(getState()) === client;
+
+    let supported: boolean;
+    try {
+      supported = await client.supports("markNotificationAsRead", payload);
+    } catch (error) {
+      if (!isCurrentClient()) return false;
+      throw error;
+    }
 
     // Capability discovery is asynchronous. If the user switched accounts or
     // instances while it was in flight, this action belongs to the old inbox.
-    if (!isCurrentClient()) return;
+    if (!isCurrentClient()) return false;
 
     if (!supported) {
       throw new UnsupportedError(
@@ -346,11 +351,16 @@ export const markNotificationRead =
     } catch (error) {
       if (isCurrentClient()) {
         dispatch(setNotificationReadStatus({ ...args, read: initialRead }));
+        throw error;
       }
-      throw error;
+
+      return false;
     }
 
-    if (isCurrentClient()) dispatch(getInboxCounts(true));
+    if (!isCurrentClient()) return false;
+
+    dispatch(getInboxCounts(true));
+    return true;
   };
 
 export const markMessageRead =

--- a/src/features/inbox/inboxSlice.ts
+++ b/src/features/inbox/inboxSlice.ts
@@ -7,6 +7,7 @@ import {
   NotificationView,
   PageCursor,
   PrivateMessageView,
+  UnsupportedError,
 } from "threadiverse";
 
 import { clientSelector, jwtSelector } from "#/features/auth/authSelectors";
@@ -313,7 +314,27 @@ export const markNotificationRead =
     read: boolean,
   ) =>
   async (dispatch: AppDispatch, getState: () => RootState) => {
-    const client = clientSelector(getState());
+    const initialState = getState();
+    const client = clientSelector(initialState);
+    const payload = {
+      kind: args.kind,
+      notification_id: args.notificationId,
+      read,
+    };
+
+    const supported = await client.supports("markNotificationAsRead", payload);
+
+    const isCurrentClient = () => clientSelector(getState()) === client;
+
+    // Capability discovery is asynchronous. If the user switched accounts or
+    // instances while it was in flight, this action belongs to the old inbox.
+    if (!isCurrentClient()) return;
+
+    if (!supported) {
+      throw new UnsupportedError(
+        `Marking ${args.kind} notifications as ${read ? "read" : "unread"} is not supported by this instance`,
+      );
+    }
 
     const key = `${args.kind}_${args.notificationId}`;
     const initialRead = !!getState().inbox.readByInboxItemId[key];
@@ -321,17 +342,15 @@ export const markNotificationRead =
     dispatch(setNotificationReadStatus({ ...args, read }));
 
     try {
-      await client.markNotificationAsRead({
-        kind: args.kind,
-        notification_id: args.notificationId,
-        read,
-      });
+      await client.markNotificationAsRead(payload);
     } catch (error) {
-      dispatch(setNotificationReadStatus({ ...args, read: initialRead }));
+      if (isCurrentClient()) {
+        dispatch(setNotificationReadStatus({ ...args, read: initialRead }));
+      }
       throw error;
     }
 
-    dispatch(getInboxCounts(true));
+    if (isCurrentClient()) dispatch(getInboxCounts(true));
   };
 
 export const markMessageRead =

--- a/src/features/moderation/ban/BanUser.tsx
+++ b/src/features/moderation/ban/BanUser.tsx
@@ -5,6 +5,7 @@ import {
   IonItem,
   IonLabel,
   IonList,
+  IonNote,
   IonSpinner,
   IonTextarea,
   IonTitle,
@@ -21,9 +22,12 @@ import AddRemoveButtons from "#/features/share/asImage/AddRemoveButtons";
 import AppHeader from "#/features/shared/AppHeader";
 import { banUser } from "#/features/user/userSlice";
 import { getHandle } from "#/helpers/lemmy";
+import { useMode } from "#/helpers/threadiverse";
 import { buildBanFailed, buildBanned } from "#/helpers/toastMessages";
 import useAppToast from "#/helpers/useAppToast";
 import { useAppDispatch } from "#/store";
+
+import { supportsCommunityBanContentAction } from "./communityBanCapabilities";
 
 import styles from "./BanUser.module.css";
 
@@ -47,6 +51,8 @@ export default function BanUser({
   const presentToast = useAppToast();
   const [loading, setLoading] = useState(false);
   const [presentActionSheet] = useIonActionSheet();
+  const mode = useMode();
+  const removeContentSupported = supportsCommunityBanContentAction(mode);
 
   const text = `Banning ${getHandle(user)} ${
     permanent ? "permanently" : `for ${days} days`
@@ -81,8 +87,8 @@ export default function BanUser({
           expires_at: !permanent
             ? Math.trunc(addDays(new Date(), days).getTime() / 1_000)
             : undefined,
-          remove_or_restore_data: removeContent,
-          ["remove_data" as never]: removeContent, // TODO lemmy 0.19.0 and less support
+          remove_or_restore_data: removeContentSupported && removeContent,
+          ["remove_data" as never]: removeContentSupported && removeContent, // TODO lemmy 0.19.0 and less support
         }),
       );
     } catch (error) {
@@ -156,12 +162,26 @@ export default function BanUser({
           )}
           <IonItem>
             <IonToggle
-              checked={removeContent}
-              onIonChange={(e) => setRemoveContent(e.detail.checked)}
+              disabled={!removeContentSupported}
+              checked={removeContentSupported && removeContent}
+              onIonChange={(e) => {
+                if (removeContentSupported) {
+                  setRemoveContent(e.detail.checked);
+                }
+              }}
             >
               Remove Content
             </IonToggle>
           </IonItem>
+          {!removeContentSupported && (
+            <div className="ion-padding-horizontal ion-padding-bottom">
+              <IonNote>
+                {mode === undefined
+                  ? "Checking server support…"
+                  : "Not supported on this server"}
+              </IonNote>
+            </div>
+          )}
         </IonList>
 
         <div className={styles.banTextContainer}>

--- a/src/features/moderation/ban/BanUser.tsx
+++ b/src/features/moderation/ban/BanUser.tsx
@@ -5,7 +5,6 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonNote,
   IonSpinner,
   IonTextarea,
   IonTitle,
@@ -165,27 +164,15 @@ export default function BanUser({
               </div>
             </IonItem>
           )}
-          <IonItem>
-            <IonToggle
-              disabled={!removeContentSupported}
-              checked={removeContentSupported && removeContent}
-              onIonChange={(e) => {
-                if (removeContentSupported) {
-                  setRemoveContent(e.detail.checked);
-                }
-              }}
-            >
-              Remove Content
-            </IonToggle>
-          </IonItem>
-          {!removeContentSupported && (
-            <div className="ion-padding-horizontal ion-padding-bottom">
-              <IonNote>
-                {mode === undefined
-                  ? "Checking server support…"
-                  : "Not supported on this server"}
-              </IonNote>
-            </div>
+          {removeContentSupported && (
+            <IonItem>
+              <IonToggle
+                checked={removeContent}
+                onIonChange={(e) => setRemoveContent(e.detail.checked)}
+              >
+                Remove Content
+              </IonToggle>
+            </IonItem>
           )}
         </IonList>
 

--- a/src/features/moderation/ban/BanUser.tsx
+++ b/src/features/moderation/ban/BanUser.tsx
@@ -77,9 +77,10 @@ export default function BanUser({
 
   async function ban() {
     setLoading(true);
+    let executed: boolean;
 
     try {
-      await dispatch(
+      executed = await dispatch(
         banUser({
           person_id: user.id,
           community_id: community.id,
@@ -97,6 +98,10 @@ export default function BanUser({
     } finally {
       setLoading(false);
     }
+
+    // Account/instance changes cancel stale mutations. Keep this dialog open
+    // and do not report success for a request that never ran for this account.
+    if (!executed) return;
 
     presentToast(buildBanned(true));
 

--- a/src/features/moderation/ban/communityBanCapabilities.test.ts
+++ b/src/features/moderation/ban/communityBanCapabilities.test.ts
@@ -1,0 +1,153 @@
+import {
+  providerSupports,
+  ThreadiverseMode,
+  UnsupportedError,
+} from "threadiverse";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  banFromCommunityWithCapabilities,
+  CommunityBanClient,
+  supportsCommunityBanContentAction,
+} from "./communityBanCapabilities";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function buildClient(supported: boolean): CommunityBanClient {
+  return {
+    banFromCommunity: vi.fn().mockResolvedValue(undefined),
+    supports: vi.fn().mockResolvedValue(supported),
+  };
+}
+
+function buildPieFedClient(): CommunityBanClient {
+  return {
+    banFromCommunity: vi.fn().mockResolvedValue(undefined),
+    supports: vi.fn((endpoint, parameters) =>
+      Promise.resolve(providerSupports("piefed", endpoint, parameters)),
+    ),
+  };
+}
+
+describe("supportsCommunityBanContentAction", () => {
+  it.each<ThreadiverseMode>(["lemmyv0", "lemmyv1"])(
+    "enables the remove-content control for %s",
+    (mode) => {
+      expect(supportsCommunityBanContentAction(mode)).toBe(true);
+    },
+  );
+
+  it("disables the remove-content control for PieFed", () => {
+    expect(supportsCommunityBanContentAction("piefed")).toBe(false);
+  });
+
+  it("keeps the control disabled until provider discovery completes", () => {
+    expect(supportsCommunityBanContentAction(undefined)).toBe(false);
+    expect(supportsCommunityBanContentAction(null)).toBe(false);
+  });
+});
+
+describe("banFromCommunityWithCapabilities", () => {
+  it.each([undefined, false])(
+    "rejects PieFed's unsupported remove/restore action when ban is %s",
+    async (ban) => {
+      const client = buildPieFedClient();
+      const payload = {
+        ban,
+        community_id: 1,
+        person_id: 2,
+        remove_or_restore_data: true,
+      };
+
+      await expect(
+        banFromCommunityWithCapabilities(client, payload, () => true),
+      ).rejects.toThrow(UnsupportedError);
+
+      expect(client.supports).toHaveBeenCalledWith("banFromCommunity", payload);
+      expect(client.banFromCommunity).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([undefined, false])(
+    "allows a supported plain ban when remove_or_restore_data is %s",
+    async (remove_or_restore_data) => {
+      const client = buildPieFedClient();
+      const payload = {
+        community_id: 1,
+        person_id: 2,
+        remove_or_restore_data,
+      };
+
+      await expect(
+        banFromCommunityWithCapabilities(client, payload, () => true),
+      ).resolves.toBe(true);
+
+      expect(client.supports).toHaveBeenCalledWith("banFromCommunity", payload);
+      expect(client.banFromCommunity).toHaveBeenCalledWith({
+        ban: true,
+        ...payload,
+      });
+    },
+  );
+
+  it("preserves an unban while preflighting the exact payload", async () => {
+    const client = buildClient(true);
+    const payload = {
+      ban: false,
+      community_id: 1,
+      person_id: 2,
+    };
+
+    await expect(
+      banFromCommunityWithCapabilities(client, payload, () => true),
+    ).resolves.toBe(true);
+
+    expect(client.supports).toHaveBeenCalledWith("banFromCommunity", payload);
+    expect(client.banFromCommunity).toHaveBeenCalledWith(payload);
+  });
+
+  it("does not preflight a client that is already stale", async () => {
+    const client = buildClient(true);
+
+    await expect(
+      banFromCommunityWithCapabilities(
+        client,
+        { community_id: 1, person_id: 2 },
+        () => false,
+      ),
+    ).resolves.toBe(false);
+
+    expect(client.supports).not.toHaveBeenCalled();
+    expect(client.banFromCommunity).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "ignores a preflight result of %s after the selected client changes",
+    async (supported) => {
+      const supportResult = deferred<boolean>();
+      const client = buildClient(true);
+      vi.mocked(client.supports).mockReturnValue(supportResult.promise);
+      let current = true;
+
+      const result = banFromCommunityWithCapabilities(
+        client,
+        { community_id: 1, person_id: 2 },
+        () => current,
+      );
+      await vi.waitFor(() => expect(client.supports).toHaveBeenCalledOnce());
+
+      current = false;
+      supportResult.resolve(supported);
+
+      await expect(result).resolves.toBe(false);
+      expect(client.banFromCommunity).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/features/moderation/ban/communityBanCapabilities.ts
+++ b/src/features/moderation/ban/communityBanCapabilities.ts
@@ -1,0 +1,64 @@
+import {
+  BanFromCommunity,
+  BanFromCommunitySupportParameters,
+  providerSupports,
+  ThreadiverseMode,
+  UnsupportedError,
+} from "threadiverse";
+
+export interface CommunityBanClient {
+  banFromCommunity(payload: BanFromCommunity): Promise<unknown>;
+  supports(
+    endpoint: "banFromCommunity",
+    parameters: BanFromCommunitySupportParameters,
+  ): Promise<boolean>;
+}
+
+/**
+ * Whether the active provider can remove (or restore) all of a user's
+ * community content as part of a ban mutation.
+ */
+export function supportsCommunityBanContentAction(
+  mode: ThreadiverseMode | null | undefined,
+): boolean {
+  if (!mode) return false;
+
+  return providerSupports(mode, "banFromCommunity", {
+    remove_or_restore_data: true,
+  });
+}
+
+/**
+ * Execute a community ban only when the provider can honor the complete
+ * payload and its client is still selected. Returns whether the remote
+ * mutation ran, so callers can skip local updates for a stale preflight.
+ */
+export async function banFromCommunityWithCapabilities(
+  client: CommunityBanClient,
+  payload: Omit<BanFromCommunity, "ban"> &
+    Partial<Pick<BanFromCommunity, "ban">>,
+  isCurrentClient: () => boolean,
+): Promise<boolean> {
+  if (!isCurrentClient()) return false;
+
+  const supported = await client.supports("banFromCommunity", payload);
+
+  // Discovery is asynchronous. Do not mutate through the old account's
+  // client if the user changed accounts or instances while it was in flight.
+  if (!isCurrentClient()) return false;
+
+  if (!supported) {
+    throw new UnsupportedError(
+      payload.remove_or_restore_data
+        ? "Removing or restoring user content with a community ban is not supported on this server"
+        : "Community bans are not supported on this server",
+    );
+  }
+
+  await client.banFromCommunity({
+    ban: true,
+    ...payload,
+  });
+
+  return true;
+}

--- a/src/features/moderation/useCommentModActions.tsx
+++ b/src/features/moderation/useCommentModActions.tsx
@@ -190,13 +190,14 @@ export default function useCommentModActions(commentView: CommentView) {
                 (async () => {
                   if (banned) {
                     try {
-                      await dispatch(
+                      const executed = await dispatch(
                         banUser({
                           person_id: commentView.creator.id,
                           community_id: commentView.community.id,
                           ban: false,
                         }),
                       );
+                      if (!executed) return;
                     } catch (error) {
                       presentToast(buildBanFailed(false));
                       throw error;

--- a/src/features/moderation/usePostModActions.tsx
+++ b/src/features/moderation/usePostModActions.tsx
@@ -156,13 +156,14 @@ export default function usePostModActions(post: PostView) {
                 (async () => {
                   if (banned) {
                     try {
-                      await dispatch(
+                      const executed = await dispatch(
                         banUser({
                           person_id: post.creator.id,
                           community_id: post.community.id,
                           ban: false,
                         }),
                       );
+                      if (!executed) return;
                     } catch (error) {
                       presentToast(buildBanFailed(false));
                       throw error;

--- a/src/features/shared/markdown/editing/uploadImageSlice.test.ts
+++ b/src/features/shared/markdown/editing/uploadImageSlice.test.ts
@@ -1,0 +1,154 @@
+import type { ThreadiverseClient } from "threadiverse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppDispatch, RootState } from "#/store";
+
+import { deletePendingImageUploads } from "./uploadImageSlice";
+
+const getClient = vi.hoisted(() => vi.fn());
+
+vi.mock("#/services/client", () => ({ getClient }));
+
+const owner = {
+  handle: "owner@piefed.example",
+  jwt: "owner-token",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createClient(supported = true) {
+  const supports = vi.fn(async () => supported);
+  const deleteImage = vi.fn(async (): Promise<void> => undefined);
+  const client = { deleteImage, supports } as unknown as ThreadiverseClient;
+
+  getClient.mockReturnValue(client);
+
+  return { client, deleteImage, supports };
+}
+
+function createImage(delete_token?: string) {
+  return {
+    _context: "body" as const,
+    _handle: owner.handle,
+    delete_token,
+    url: "https://piefed.example/media/image.webp",
+  };
+}
+
+function createState(
+  image: ReturnType<typeof createImage>,
+  accounts: Array<{ handle: string; jwt?: string }> = [owner],
+): RootState {
+  return {
+    auth: {
+      accountData: {
+        accounts,
+        activeHandle: accounts[0]?.handle,
+      },
+    },
+    uploadImage: { pendingSubmitImages: [image] },
+  } as unknown as RootState;
+}
+
+describe("deletePendingImageUploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preflights and preserves the token-based Lemmy deletion path", async () => {
+    const image = createImage("lemmy-delete-token");
+    const state = createState(image);
+    const { deleteImage, supports } = createClient();
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await deletePendingImageUploads()(dispatch, () => state);
+
+    expect(getClient).toHaveBeenCalledWith("piefed.example", owner.jwt);
+    expect(supports).toHaveBeenCalledWith("deleteImage", {
+      delete_token: "lemmy-delete-token",
+      url: image.url,
+    });
+    expect(deleteImage).toHaveBeenCalledWith({
+      delete_token: "lemmy-delete-token",
+      url: image.url,
+    });
+  });
+
+  it("deletes a tokenless upload through its owning account when supported", async () => {
+    const image = createImage();
+    const state = createState(image, [
+      { handle: "active@lemmy.example", jwt: "active-token" },
+      owner,
+    ]);
+    const { deleteImage, supports } = createClient();
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await deletePendingImageUploads()(dispatch, () => state);
+
+    expect(getClient).toHaveBeenCalledWith("piefed.example", owner.jwt);
+    expect(supports).toHaveBeenCalledWith("deleteImage", {
+      delete_token: "",
+      url: image.url,
+    });
+    expect(deleteImage).toHaveBeenCalledWith({
+      delete_token: "",
+      url: image.url,
+    });
+  });
+
+  it("skips a tokenless upload when the provider cannot delete it", async () => {
+    const image = createImage();
+    const state = createState(image);
+    const { deleteImage, supports } = createClient(false);
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await deletePendingImageUploads()(dispatch, () => state);
+
+    expect(supports).toHaveBeenCalledWith("deleteImage", {
+      delete_token: "",
+      url: image.url,
+    });
+    expect(deleteImage).not.toHaveBeenCalled();
+  });
+
+  it("does not construct a client when the upload's owning account is gone", async () => {
+    const image = createImage();
+    const state = createState(image, []);
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await deletePendingImageUploads()(dispatch, () => state);
+
+    expect(getClient).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["tokenless", undefined],
+    ["token-based", "lemmy-delete-token"],
+  ] as const)(
+    "does not delete a %s upload through a credential replaced during capability discovery",
+    async (_label, deleteToken) => {
+      const image = createImage(deleteToken);
+      let state = createState(image);
+      const supportResult = deferred<boolean>();
+      const { deleteImage, supports } = createClient();
+      supports.mockReturnValue(supportResult.promise);
+      const dispatch = vi.fn() as unknown as AppDispatch;
+
+      const result = deletePendingImageUploads()(dispatch, () => state);
+      await vi.waitFor(() => expect(supports).toHaveBeenCalledOnce());
+
+      state = createState(image, [{ ...owner, jwt: "replacement-token" }]);
+      supportResult.resolve(true);
+      await result;
+
+      expect(deleteImage).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/features/shared/markdown/editing/uploadImageSlice.tsx
+++ b/src/features/shared/markdown/editing/uploadImageSlice.tsx
@@ -94,9 +94,6 @@ export const deletePendingImageUploads =
     try {
       await Promise.all(
         toRemove.map(async (img) => {
-          const delete_token = img.delete_token;
-          if (!delete_token) return;
-
           const account = getState().auth.accountData?.accounts.find(
             ({ handle }) => handle === img._handle,
           );
@@ -108,7 +105,24 @@ export const deletePendingImageUploads =
             account.jwt,
           );
 
-          await client.deleteImage({ url: img.url, delete_token });
+          // Lemmy v0 requires its per-image deletion token; PieFed and Lemmy
+          // v1 own uploads through the authenticated account and may not
+          // return one. Preflight the exact payload so the provider decides.
+          const payload = {
+            url: img.url,
+            delete_token: img.delete_token ?? "",
+          };
+          if (!(await client.supports("deleteImage", payload))) return;
+
+          // Capability discovery is asynchronous. The credential that owns
+          // this image may have been removed or replaced while it was in
+          // flight; never delete through a stale account client.
+          const currentAccount = getState().auth.accountData?.accounts.find(
+            ({ handle }) => handle === img._handle,
+          );
+          if (!currentAccount || currentAccount.jwt !== account.jwt) return;
+
+          await client.deleteImage(payload);
         }),
       );
     } finally {

--- a/src/features/user/Profile.tsx
+++ b/src/features/user/Profile.tsx
@@ -30,6 +30,7 @@ import useClient from "#/helpers/useClient";
 import { LIMIT } from "#/services/lemmy";
 import { useAppDispatch, useAppSelector } from "#/store";
 
+import { supportsProfileVotedFeed } from "./profileCapabilities";
 import Scores from "./Scores";
 
 interface ProfileProps extends Pick<
@@ -50,6 +51,9 @@ export default function Profile({ person, onPull }: ProfileProps) {
   const dispatch = useAppDispatch();
 
   const isSelf = getRemoteHandle(person.person) === myHandle;
+  const supportsUpvoted = supportsProfileVotedFeed(mode, "liked_only") === true;
+  const supportsDownvoted =
+    supportsProfileVotedFeed(mode, "disliked_only") === true;
 
   const fetchFn: FetchFn<PostCommentItem> = async (page_cursor, ...rest) => {
     const response = await client.listPersonContent(
@@ -106,27 +110,27 @@ export default function Profile({ person, onPull }: ProfileProps) {
               <IonIcon icon={bookmarkOutline} color="primary" slot="start" />{" "}
               <IonLabel className="ion-text-nowrap">Saved</IonLabel>
             </IonItem>
-            {mode !== "piefed" && (
-              <>
-                <IonItem
-                  routerLink={buildGeneralBrowseLink(
-                    `/u/${getHandle(person.person)}/upvoted`,
-                  )}
-                  detail
-                >
-                  <IonIcon icon={arrowUp} color="primary" slot="start" />{" "}
-                  <IonLabel className="ion-text-nowrap">Upvoted</IonLabel>
-                </IonItem>
-                <IonItem
-                  routerLink={buildGeneralBrowseLink(
-                    `/u/${getHandle(person.person)}/downvoted`,
-                  )}
-                  detail
-                >
-                  <IonIcon icon={arrowDown} color="primary" slot="start" />{" "}
-                  <IonLabel className="ion-text-nowrap">Downvoted</IonLabel>
-                </IonItem>
-              </>
+            {supportsUpvoted && (
+              <IonItem
+                routerLink={buildGeneralBrowseLink(
+                  `/u/${getHandle(person.person)}/upvoted`,
+                )}
+                detail
+              >
+                <IonIcon icon={arrowUp} color="primary" slot="start" />{" "}
+                <IonLabel className="ion-text-nowrap">Upvoted</IonLabel>
+              </IonItem>
+            )}
+            {supportsDownvoted && (
+              <IonItem
+                routerLink={buildGeneralBrowseLink(
+                  `/u/${getHandle(person.person)}/downvoted`,
+                )}
+                detail
+              >
+                <IonIcon icon={arrowDown} color="primary" slot="start" />{" "}
+                <IonLabel className="ion-text-nowrap">Downvoted</IonLabel>
+              </IonItem>
             )}
             <IonItem
               routerLink={buildGeneralBrowseLink(

--- a/src/features/user/profileCapabilities.ts
+++ b/src/features/user/profileCapabilities.ts
@@ -1,0 +1,19 @@
+import { LikeType, providerSupports, ThreadiverseMode } from "threadiverse";
+
+export type ProfileVotedMode = ThreadiverseMode | null | undefined;
+
+/**
+ * `undefined` means provider discovery is still in progress. `false` means the
+ * active provider is known and cannot honor this particular voted-feed query.
+ */
+export function supportsProfileVotedFeed(
+  mode: ProfileVotedMode,
+  likeType: LikeType,
+): boolean | undefined {
+  if (mode === undefined) return;
+  if (mode === null) return false;
+
+  return providerSupports(mode, "listPersonLiked", {
+    like_type: likeType,
+  });
+}

--- a/src/features/user/userSlice.test.tsx
+++ b/src/features/user/userSlice.test.tsx
@@ -1,0 +1,83 @@
+import type { ThreadiverseClient } from "threadiverse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppDispatch, RootState } from "#/store";
+
+import { banUser, updateBanned } from "./userSlice";
+
+const selectedClient = vi.hoisted(() => ({
+  current: undefined as unknown as ThreadiverseClient,
+}));
+
+vi.mock("#/features/auth/authSelectors", async (importOriginal) => ({
+  ...(await importOriginal()),
+  clientSelector: () => selectedClient.current,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createClient() {
+  const supports = vi.fn(async () => true);
+  const banFromCommunity = vi.fn(async (): Promise<void> => undefined);
+  const client = {
+    banFromCommunity,
+    supports,
+  } as unknown as ThreadiverseClient;
+
+  return { banFromCommunity, client, supports };
+}
+
+const state = {} as RootState;
+
+describe("banUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not apply an old client's completed ban after an account switch", async () => {
+    const endpointResult = deferred<void>();
+    const first = createClient();
+    const second = createClient();
+    first.banFromCommunity.mockReturnValue(endpointResult.promise);
+    selectedClient.current = first.client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    const result = banUser({
+      community_id: 1,
+      person_id: 2,
+    })(dispatch, () => state);
+
+    await vi.waitFor(() => {
+      expect(first.banFromCommunity).toHaveBeenCalledOnce();
+    });
+
+    selectedClient.current = second.client;
+    endpointResult.resolve();
+    await result;
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("records an unban only while its client remains selected", async () => {
+    const { client } = createClient();
+    selectedClient.current = client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await banUser({
+      ban: false,
+      community_id: 1,
+      person_id: 2,
+    })(dispatch, () => state);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      updateBanned({ banned: false, communityId: 1, userId: 2 }),
+    );
+  });
+});

--- a/src/features/user/userSlice.test.tsx
+++ b/src/features/user/userSlice.test.tsx
@@ -16,11 +16,13 @@ vi.mock("#/features/auth/authSelectors", async (importOriginal) => ({
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
 
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function createClient() {
@@ -60,9 +62,95 @@ describe("banUser", () => {
 
     selectedClient.current = second.client;
     endpointResult.resolve();
-    await result;
+    await expect(result).resolves.toBe(false);
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("suppresses an old client's rejected ban after an account switch", async () => {
+    const endpointResult = deferred<void>();
+    const first = createClient();
+    const second = createClient();
+    first.banFromCommunity.mockReturnValue(endpointResult.promise);
+    selectedClient.current = first.client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    const result = banUser({
+      community_id: 1,
+      person_id: 2,
+    })(dispatch, () => state);
+
+    await vi.waitFor(() => {
+      expect(first.banFromCommunity).toHaveBeenCalledOnce();
+    });
+
+    selectedClient.current = second.client;
+    endpointResult.reject(new Error("old client failed"));
+
+    await expect(result).resolves.toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("suppresses an old client's rejected capability check after an account switch", async () => {
+    const supportResult = deferred<boolean>();
+    const first = createClient();
+    const second = createClient();
+    first.supports.mockReturnValue(supportResult.promise);
+    selectedClient.current = first.client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    const result = banUser({
+      community_id: 1,
+      person_id: 2,
+    })(dispatch, () => state);
+
+    await vi.waitFor(() => expect(first.supports).toHaveBeenCalledOnce());
+
+    selectedClient.current = second.client;
+    supportResult.reject(new Error("old discovery failed"));
+
+    await expect(result).resolves.toBe(false);
+    expect(first.banFromCommunity).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("propagates a failure from the active client", async () => {
+    const failure = new Error("active client failed");
+    const first = createClient();
+    first.banFromCommunity.mockRejectedValue(failure);
+    selectedClient.current = first.client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await expect(
+      banUser({ community_id: 1, person_id: 2 })(dispatch, () => state),
+    ).rejects.toBe(failure);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("reports cancellation when no client is selected", async () => {
+    selectedClient.current = undefined as unknown as ThreadiverseClient;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await expect(
+      banUser({ community_id: 1, person_id: 2 })(dispatch, () => state),
+    ).resolves.toBe(false);
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("records a default ban and reports execution", async () => {
+    const { client } = createClient();
+    selectedClient.current = client;
+    const dispatch = vi.fn() as unknown as AppDispatch;
+
+    await expect(
+      banUser({ community_id: 1, person_id: 2 })(dispatch, () => state),
+    ).resolves.toBe(true);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      updateBanned({ banned: true, communityId: 1, userId: 2 }),
+    );
   });
 
   it("records an unban only while its client remains selected", async () => {
@@ -70,11 +158,13 @@ describe("banUser", () => {
     selectedClient.current = client;
     const dispatch = vi.fn() as unknown as AppDispatch;
 
-    await banUser({
-      ban: false,
-      community_id: 1,
-      person_id: 2,
-    })(dispatch, () => state);
+    await expect(
+      banUser({
+        ban: false,
+        community_id: 1,
+        person_id: 2,
+      })(dispatch, () => state),
+    ).resolves.toBe(true);
 
     expect(dispatch).toHaveBeenCalledWith(
       updateBanned({ banned: false, communityId: 1, userId: 2 }),

--- a/src/features/user/userSlice.tsx
+++ b/src/features/user/userSlice.tsx
@@ -4,6 +4,7 @@ import { BanFromCommunity, Person } from "threadiverse";
 import { clientSelector } from "#/features/auth/authSelectors";
 import { getSite } from "#/features/auth/siteSlice";
 import { resetMessages, syncMessages } from "#/features/inbox/inboxSlice";
+import { banFromCommunityWithCapabilities } from "#/features/moderation/ban/communityBanCapabilities";
 import { getHandle } from "#/helpers/lemmy";
 import { AppDispatch, RootState } from "#/store";
 
@@ -109,16 +110,26 @@ export const banUser =
       Partial<Pick<BanFromCommunity, "ban">>,
   ) =>
   async (dispatch: AppDispatch, getState: () => RootState) => {
-    await clientSelector(getState())?.banFromCommunity({
-      ban: true,
-      ...payload,
-    });
+    const client = clientSelector(getState());
+
+    if (!client) return;
+
+    const isCurrentClient = () => clientSelector(getState()) === client;
+    const executed = await banFromCommunityWithCapabilities(
+      client,
+      payload,
+      isCurrentClient,
+    );
+
+    // The request may have completed after an account switch. Its remote
+    // result belongs to the old account and must not update the new store.
+    if (!executed || !isCurrentClient()) return;
 
     dispatch(
       updateBanned({
         communityId: payload.community_id,
         userId: payload.person_id,
-        banned: true,
+        banned: payload.ban ?? true,
       }),
     );
   };

--- a/src/features/user/userSlice.tsx
+++ b/src/features/user/userSlice.tsx
@@ -112,18 +112,27 @@ export const banUser =
   async (dispatch: AppDispatch, getState: () => RootState) => {
     const client = clientSelector(getState());
 
-    if (!client) return;
+    if (!client) return false;
 
     const isCurrentClient = () => clientSelector(getState()) === client;
-    const executed = await banFromCommunityWithCapabilities(
-      client,
-      payload,
-      isCurrentClient,
-    );
+    let executed: boolean;
+
+    try {
+      executed = await banFromCommunityWithCapabilities(
+        client,
+        payload,
+        isCurrentClient,
+      );
+    } catch (error) {
+      // A failure from an account that is no longer selected must not leak
+      // into the new account's UI. Active-client failures still propagate.
+      if (!isCurrentClient()) return false;
+      throw error;
+    }
 
     // The request may have completed after an account switch. Its remote
     // result belongs to the old account and must not update the new store.
-    if (!executed || !isCurrentClient()) return;
+    if (!executed || !isCurrentClient()) return false;
 
     dispatch(
       updateBanned({
@@ -132,4 +141,6 @@ export const banUser =
         banned: payload.ban ?? true,
       }),
     );
+
+    return true;
   };

--- a/src/routes/pages/profile/BaseProfileFeedItemsPage.tsx
+++ b/src/routes/pages/profile/BaseProfileFeedItemsPage.tsx
@@ -14,11 +14,13 @@ import FeedContent from "#/routes/pages/shared/FeedContent";
 interface BaseProfileFeedItemsPageProps {
   label: string;
   fetchFn: FetchFn<PostCommentItem>;
+  renderCustomEmptyContent?: () => React.ReactNode;
   sortComponent?: React.ReactNode;
 }
 
 export default function BaseProfileFeedItemsPage({
   fetchFn,
+  renderCustomEmptyContent,
   sortComponent,
   label,
 }: BaseProfileFeedItemsPageProps) {
@@ -46,6 +48,7 @@ export default function BaseProfileFeedItemsPage({
           fetchFn={fetchFn}
           filterHiddenPosts={false}
           filterKeywordsAndWebsites={false}
+          renderCustomEmptyContent={renderCustomEmptyContent}
         />
       </FeedContent>
     </AppPage>

--- a/src/routes/pages/profile/BaseProfileFeedItemsPage.tsx
+++ b/src/routes/pages/profile/BaseProfileFeedItemsPage.tsx
@@ -14,13 +14,11 @@ import FeedContent from "#/routes/pages/shared/FeedContent";
 interface BaseProfileFeedItemsPageProps {
   label: string;
   fetchFn: FetchFn<PostCommentItem>;
-  renderCustomEmptyContent?: () => React.ReactNode;
   sortComponent?: React.ReactNode;
 }
 
 export default function BaseProfileFeedItemsPage({
   fetchFn,
-  renderCustomEmptyContent,
   sortComponent,
   label,
 }: BaseProfileFeedItemsPageProps) {
@@ -48,7 +46,6 @@ export default function BaseProfileFeedItemsPage({
           fetchFn={fetchFn}
           filterHiddenPosts={false}
           filterKeywordsAndWebsites={false}
-          renderCustomEmptyContent={renderCustomEmptyContent}
         />
       </FeedContent>
     </AppPage>

--- a/src/routes/pages/profile/ProfileFeedCommentsPage.tsx
+++ b/src/routes/pages/profile/ProfileFeedCommentsPage.tsx
@@ -1,10 +1,12 @@
+import { CommentSort } from "#/features/comment/CommentSort";
 import { AbortLoadError, FetchFn } from "#/features/feed/Feed";
 import { PostCommentItem } from "#/features/feed/PostCommentFeed";
-import { SearchSort } from "#/features/feed/sort/SearchSort";
 import useFeedSort, {
-  useFeedSortParams,
+  getProfileCommentSort,
+  getProfileCommentSortParams,
 } from "#/features/feed/sort/useFeedSort";
 import { getUserIfNeeded } from "#/features/user/userSlice";
+import { useMode } from "#/helpers/threadiverse";
 import useClient from "#/helpers/useClient";
 import useRequiredParams from "#/helpers/useRequiredParams";
 import { LIMIT } from "#/services/lemmy";
@@ -16,15 +18,17 @@ export default function ProfileFeedCommentsPage() {
   const client = useClient();
   const { handle } = useRequiredParams<{ handle: string }>();
   const dispatch = useAppDispatch();
+  const mode = useMode();
 
   const [sort, setSort] = useFeedSort(
-    "search",
+    "comments",
     {
       internal: `ProfileComments`,
     },
     "New",
   );
-  const sortParams = useFeedSortParams("search", sort);
+  const effectiveSort = getProfileCommentSort(mode, sort);
+  const sortParams = getProfileCommentSortParams(mode, effectiveSort);
 
   const fetchFn: FetchFn<PostCommentItem> = async (page_cursor, ...rest) => {
     if (sortParams === undefined) throw new AbortLoadError();
@@ -47,7 +51,11 @@ export default function ProfileFeedCommentsPage() {
     <BaseProfileFeedItemsPage
       label="Comments"
       fetchFn={fetchFn}
-      sortComponent={<SearchSort sort={sort} setSort={setSort} />}
+      sortComponent={
+        mode !== "lemmyv1" && (
+          <CommentSort sort={effectiveSort} setSort={setSort} />
+        )
+      }
     />
   );
 }

--- a/src/routes/pages/profile/ProfileFeedPostsPage.tsx
+++ b/src/routes/pages/profile/ProfileFeedPostsPage.tsx
@@ -1,10 +1,12 @@
 import { AbortLoadError, FetchFn } from "#/features/feed/Feed";
 import { PostCommentItem } from "#/features/feed/PostCommentFeed";
-import { SearchSort } from "#/features/feed/sort/SearchSort";
+import { PostSort } from "#/features/feed/sort/PostSort";
 import useFeedSort, {
-  useFeedSortParams,
+  getProfilePostSort,
+  getProfilePostSortParams,
 } from "#/features/feed/sort/useFeedSort";
 import { getUserIfNeeded } from "#/features/user/userSlice";
+import { useMode } from "#/helpers/threadiverse";
 import useClient from "#/helpers/useClient";
 import useRequiredParams from "#/helpers/useRequiredParams";
 import { LIMIT } from "#/services/lemmy";
@@ -16,15 +18,17 @@ export default function ProfileFeedPostsPage() {
   const client = useClient();
   const { handle } = useRequiredParams<{ handle: string }>();
   const dispatch = useAppDispatch();
+  const mode = useMode();
 
   const [sort, setSort] = useFeedSort(
-    "search",
+    "posts",
     {
       internal: `ProfilePosts`,
     },
     "New",
   );
-  const sortParams = useFeedSortParams("search", sort ?? "New");
+  const effectiveSort = getProfilePostSort(mode, sort);
+  const sortParams = getProfilePostSortParams(mode, effectiveSort);
 
   const fetchFn: FetchFn<PostCommentItem> = async (page_cursor, ...rest) => {
     if (sortParams === undefined) throw new AbortLoadError();
@@ -47,7 +51,11 @@ export default function ProfileFeedPostsPage() {
     <BaseProfileFeedItemsPage
       label="Posts"
       fetchFn={fetchFn}
-      sortComponent={<SearchSort sort={sort} setSort={setSort} />}
+      sortComponent={
+        mode !== "lemmyv1" && (
+          <PostSort sort={effectiveSort} setSort={setSort} />
+        )
+      }
     />
   );
 }

--- a/src/routes/pages/profile/ProfileFeedVotedPage.tsx
+++ b/src/routes/pages/profile/ProfileFeedVotedPage.tsx
@@ -2,14 +2,10 @@ import { LikeType } from "threadiverse";
 
 import { FetchFn } from "#/features/feed/Feed";
 import { PostCommentItem } from "#/features/feed/PostCommentFeed";
-import { supportsProfileVotedFeed } from "#/features/user/profileCapabilities";
-import { useMode } from "#/helpers/threadiverse";
 import useClient from "#/helpers/useClient";
 
 import BaseProfileFeedItemsPage from "./BaseProfileFeedItemsPage";
 import { fetchProfileVotedPage } from "./profileVoted";
-
-import endPostStyles from "#/features/feed/endItems/EndPost.module.css";
 
 const LABELS: Record<LikeType, string> = {
   disliked_only: "Downvoted",
@@ -24,26 +20,12 @@ export default function ProfileFeedVotedPage({
   likeType,
 }: ProfileFeedVotedPageProps) {
   const client = useClient();
-  const mode = useMode();
-  const supported = supportsProfileVotedFeed(mode, likeType);
 
   const fetchFn: FetchFn<PostCommentItem> = async (page_cursor, ...rest) => {
     return fetchProfileVotedPage(client, likeType, page_cursor, ...rest);
   };
 
   return (
-    <BaseProfileFeedItemsPage
-      label={LABELS[likeType]}
-      fetchFn={fetchFn}
-      renderCustomEmptyContent={
-        supported === false
-          ? () => (
-              <div className={endPostStyles.container}>
-                {LABELS[likeType]} history is not available on this server.
-              </div>
-            )
-          : undefined
-      }
-    />
+    <BaseProfileFeedItemsPage label={LABELS[likeType]} fetchFn={fetchFn} />
   );
 }

--- a/src/routes/pages/profile/ProfileFeedVotedPage.tsx
+++ b/src/routes/pages/profile/ProfileFeedVotedPage.tsx
@@ -2,10 +2,12 @@ import { LikeType } from "threadiverse";
 
 import { FetchFn } from "#/features/feed/Feed";
 import { PostCommentItem } from "#/features/feed/PostCommentFeed";
+import { supportsProfileVotedFeed } from "#/features/user/profileCapabilities";
+import { useMode } from "#/helpers/threadiverse";
 import useClient from "#/helpers/useClient";
-import { LIMIT } from "#/services/lemmy";
 
 import BaseProfileFeedItemsPage from "./BaseProfileFeedItemsPage";
+import { fetchProfileVotedPage } from "./profileVoted";
 
 const LABELS: Record<LikeType, string> = {
   disliked_only: "Downvoted",
@@ -20,15 +22,26 @@ export default function ProfileFeedVotedPage({
   likeType,
 }: ProfileFeedVotedPageProps) {
   const client = useClient();
+  const mode = useMode();
+  const supported = supportsProfileVotedFeed(mode, likeType);
 
   const fetchFn: FetchFn<PostCommentItem> = async (page_cursor, ...rest) => {
-    return client.listPersonLiked(
-      { page_cursor, like_type: likeType, limit: LIMIT },
-      ...rest,
-    );
+    return fetchProfileVotedPage(client, likeType, page_cursor, ...rest);
   };
 
   return (
-    <BaseProfileFeedItemsPage label={LABELS[likeType]} fetchFn={fetchFn} />
+    <BaseProfileFeedItemsPage
+      label={LABELS[likeType]}
+      fetchFn={fetchFn}
+      renderCustomEmptyContent={
+        supported === false
+          ? () => (
+              <div className="ion-padding ion-text-center">
+                {LABELS[likeType]} history is not available on this server.
+              </div>
+            )
+          : undefined
+      }
+    />
   );
 }

--- a/src/routes/pages/profile/ProfileFeedVotedPage.tsx
+++ b/src/routes/pages/profile/ProfileFeedVotedPage.tsx
@@ -9,6 +9,8 @@ import useClient from "#/helpers/useClient";
 import BaseProfileFeedItemsPage from "./BaseProfileFeedItemsPage";
 import { fetchProfileVotedPage } from "./profileVoted";
 
+import endPostStyles from "#/features/feed/endItems/EndPost.module.css";
+
 const LABELS: Record<LikeType, string> = {
   disliked_only: "Downvoted",
   liked_only: "Upvoted",
@@ -36,7 +38,7 @@ export default function ProfileFeedVotedPage({
       renderCustomEmptyContent={
         supported === false
           ? () => (
-              <div className="ion-padding ion-text-center">
+              <div className={endPostStyles.container}>
                 {LABELS[likeType]} history is not available on this server.
               </div>
             )

--- a/src/routes/pages/profile/profileVoted.test.ts
+++ b/src/routes/pages/profile/profileVoted.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { supportsProfileVotedFeed } from "#/features/user/profileCapabilities";
+import { LIMIT } from "#/services/lemmy";
+
+import { fetchProfileVotedPage, ProfileVotedClient } from "./profileVoted";
+
+describe("profile voted-feed capabilities", () => {
+  it("offers both voted feeds on Lemmy", () => {
+    for (const mode of ["lemmyv0", "lemmyv1"] as const) {
+      expect(supportsProfileVotedFeed(mode, "liked_only")).toBe(true);
+      expect(supportsProfileVotedFeed(mode, "disliked_only")).toBe(true);
+    }
+  });
+
+  it("offers only the supported upvoted feed on PieFed", () => {
+    expect(supportsProfileVotedFeed("piefed", "liked_only")).toBe(true);
+    expect(supportsProfileVotedFeed("piefed", "disliked_only")).toBe(false);
+  });
+
+  it("distinguishes pending discovery from a failed discovery", () => {
+    expect(supportsProfileVotedFeed(undefined, "liked_only")).toBeUndefined();
+    expect(supportsProfileVotedFeed(null, "liked_only")).toBe(false);
+  });
+
+  it("does not call listPersonLiked when the deep-link query is unsupported", async () => {
+    const supports = vi.fn(async () => false);
+    const listPersonLiked = vi.fn();
+    const client = {
+      supports,
+      listPersonLiked,
+    } as unknown as ProfileVotedClient;
+
+    await expect(
+      fetchProfileVotedPage(client, "disliked_only", undefined),
+    ).resolves.toEqual({ data: [] });
+
+    expect(supports).toHaveBeenCalledWith("listPersonLiked", {
+      like_type: "disliked_only",
+    });
+    expect(listPersonLiked).not.toHaveBeenCalled();
+  });
+
+  it("forwards supported queries and request options exactly", async () => {
+    const response = { data: [], next_page: "post:3" };
+    const supports = vi.fn(async () => true);
+    const listPersonLiked = vi.fn(async () => response);
+    const client = {
+      supports,
+      listPersonLiked,
+    } as unknown as ProfileVotedClient;
+    const controller = new AbortController();
+
+    await expect(
+      fetchProfileVotedPage(client, "liked_only", "post:2", {
+        signal: controller.signal,
+      }),
+    ).resolves.toBe(response);
+
+    expect(listPersonLiked).toHaveBeenCalledWith(
+      {
+        page_cursor: "post:2",
+        like_type: "liked_only",
+        limit: LIMIT,
+      },
+      { signal: controller.signal },
+    );
+  });
+});

--- a/src/routes/pages/profile/profileVoted.ts
+++ b/src/routes/pages/profile/profileVoted.ts
@@ -1,0 +1,37 @@
+import {
+  LikeType,
+  PageCursor,
+  RequestOptions,
+  ThreadiverseClient,
+} from "threadiverse";
+
+import { LIMIT } from "#/services/lemmy";
+
+export type ProfileVotedClient = Pick<
+  ThreadiverseClient,
+  "listPersonLiked" | "supports"
+>;
+
+/** Resolve support before calling the voted-feed endpoint for a deep link. */
+export async function fetchProfileVotedPage(
+  client: ProfileVotedClient,
+  likeType: LikeType,
+  page_cursor: PageCursor | undefined,
+  options?: RequestOptions,
+) {
+  const supported = await client.supports("listPersonLiked", {
+    like_type: likeType,
+  });
+  if (!supported) return { data: [] };
+
+  // `supports()` connects implicitly, so this also works when a deep link is
+  // opened before Voyager's provider discovery has populated Redux.
+  return client.listPersonLiked(
+    {
+      page_cursor,
+      like_type: likeType,
+      limit: LIMIT,
+    },
+    options,
+  );
+}

--- a/src/routes/pages/shared/Sort.tsx
+++ b/src/routes/pages/shared/Sort.tsx
@@ -203,7 +203,7 @@ function findSortOption<S>(sort: S, sortOptions: HydratedSortOptions<S>) {
 }
 
 export function findSortOptionUnhydrated<S>(
-  sort: S,
+  sort: unknown,
   sortOptions: SortOptions<S>,
 ) {
   for (const option of sortOptions) {

--- a/src/routes/pages/shared/Sort.tsx
+++ b/src/routes/pages/shared/Sort.tsx
@@ -202,24 +202,6 @@ function findSortOption<S>(sort: S, sortOptions: HydratedSortOptions<S>) {
   }
 }
 
-export function findSortOptionUnhydrated<S>(
-  sort: unknown,
-  sortOptions: SortOptions<S>,
-) {
-  for (const option of sortOptions) {
-    if (typeof option === "string") {
-      if (option === sort) return option;
-    } else if (
-      typeof option === "object" &&
-      option !== null &&
-      "children" in option
-    ) {
-      const matchingChild = option.children.find((child) => child === sort);
-      if (matchingChild) return matchingChild;
-    }
-  }
-}
-
 export type AnyVgerSort =
   | VgerPostSortType
   | VgerCommentSortType


### PR DESCRIPTION
## Summary

- use Threadiverse request-aware capability checks instead of provider-name assumptions
- expose PieFed upvoted profile content while omitting unsupported downvoted UI
- map profile post and comment sorts to each provider and normalize stale remembered sorts
- preflight community bans, inbox reads, registration, and image cleanup with the exact outgoing payload
- cancel stale account actions without misleading success/failure UI or Redux writes
- keep pure sort validation out of the React UI module dependency cycle
- add focused coverage for capability decisions and race handling

## Visible UX

- PieFed own-profile menus gain the existing `Upvoted` row and simply omit `Downvoted`. Lemmy menus remain unchanged.
- PieFed profile Posts and Comments use Voyager's existing sort action sheet with only provider-supported choices. Lemmy v0 comments use comment vocabulary, and Lemmy v1 hides the nonfunctional sort control.
- PieFed ban dialogs omit the unsupported `Remove Content` row. Lemmy retains its existing toggle.
- unsupported signup uses the existing Ionic alert with direct copy: `Voyager can't create accounts on <server>.`
- inbox, upload cleanup, direct-route capability guards, and account-switch protections do not alter normal presentation.

No custom visual system, CSS, icons, unsupported-feed message, redirect, or replacement control was added. An earlier disabled ban note was removed during visual review in favor of simply omitting the unsupported row.

## Dependency

Depends on aeharding/threadiverse#77 and a subsequent Threadiverse package release containing that PR.

This PR intentionally remains a draft with the manifest on released `threadiverse@0.21.2`. Before marking it ready, bump the dependency to the release containing #77. Registry-based GitHub jobs therefore stop at the expected missing capability exports; the exact cross-repository commit pair below was validated by packing Threadiverse and installing that tarball into an isolated Voyager checkout.

## Validation

Exact pair: Threadiverse `56c52e5` + Voyager `6a7999ea`.

- packed Threadiverse build, tarball SHA-256, resolved artifact, and capability exports verified
- Voyager typecheck, full ESLint with zero warnings, and full Prettier passed
- 7 focused files / 48 tests passed
- full unit suite: 25 files / 302 passed / 1 todo
- production PWA build passed; 3,194 modules transformed and service worker generated
